### PR TITLE
feat: initialize npm workspaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,31 @@
+{
+  "name": "translate",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "translate",
+      "version": "1.0.0",
+      "workspaces": [
+        "packages/*"
+      ]
+    },
+    "node_modules/@let-value/translate": {
+      "resolved": "packages/translate",
+      "link": true
+    },
+    "node_modules/@let-value/translate-extract": {
+      "resolved": "packages/extract",
+      "link": true
+    },
+    "packages/extract": {
+      "name": "@let-value/translate-extract",
+      "version": "1.0.0"
+    },
+    "packages/translate": {
+      "name": "@let-value/translate",
+      "version": "1.0.0"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "translate",
+  "version": "1.0.0",
+  "private": true,
+  "workspaces": ["packages/*"],
+  "scripts": {
+    "build": "npm run build --workspaces",
+    "lint": "npm run lint --workspaces",
+    "test": "npm run test --workspaces"
+  }
+}

--- a/packages/extract/package.json
+++ b/packages/extract/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@let-value/translate-extract",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "build": "echo building extract",
+    "lint": "echo linting extract",
+    "test": "echo testing extract"
+  }
+}

--- a/packages/translate/package.json
+++ b/packages/translate/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@let-value/translate",
+  "version": "1.0.0",
+  "main": "index.js",
+  "exports": {
+    ".": "./index.js",
+    "./extract": "../extract/index.js"
+  },
+  "scripts": {
+    "build": "echo building translate",
+    "lint": "echo linting translate",
+    "test": "echo testing translate"
+  }
+}


### PR DESCRIPTION
## Summary
- set up npm workspace root with build, lint, and test scripts
- add translate and extract packages with their own scripts
- scope packages under @let-value and expose extract via a subpath

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b197fe6190832f8ed1206a1c46899d