### PR TITLE
Add tests for msg function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1486,7 +1486,10 @@
     },
     "packages/translate": {
       "name": "@let-value/translate",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "devDependencies": {
+        "tsx": "^4.20.5"
+      }
     }
   }
 }

--- a/packages/translate/package.json
+++ b/packages/translate/package.json
@@ -11,6 +11,9 @@
   "scripts": {
     "build": "echo building translate",
     "lint": "echo linting translate",
-    "test": "echo testing translate"
+    "test": "tsx --test test/msg.test.ts"
+  }
+  ,"devDependencies": {
+    "tsx": "^4.20.5"
   }
 }

--- a/packages/translate/test/msg.test.ts
+++ b/packages/translate/test/msg.test.ts
@@ -1,0 +1,34 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { msg } from '../src/index.ts';
+
+test('msg with string returns id and message', () => {
+  assert.deepEqual(msg('hello'), { id: 'hello', message: 'hello' });
+});
+
+test('msg with descriptor uses id and message', () => {
+  const descriptor = { id: 'greeting', message: 'Hello world' };
+  assert.deepEqual(msg(descriptor), { id: 'greeting', message: 'Hello world' });
+});
+
+test('msg with descriptor id only uses it for message too', () => {
+  const descriptor = { id: 'onlyId' };
+  assert.deepEqual(msg(descriptor), { id: 'onlyId', message: 'onlyId' });
+});
+
+test('msg with descriptor message only uses it for id too', () => {
+  const descriptor = { message: 'onlyMessage' };
+  assert.deepEqual(msg(descriptor), { id: 'onlyMessage', message: 'onlyMessage' });
+});
+
+test('msg with template string returns composed id and message', () => {
+  const name = 'World';
+  assert.deepEqual(msg`Hello, ${name}!`, {
+    id: 'Hello, World!',
+    message: 'Hello, World!',
+  });
+});
+
+test('msg with invalid argument throws', () => {
+  assert.throws(() => msg(123 as any), { message: 'Invalid msg argument' });
+});


### PR DESCRIPTION
## Summary
- add unit tests for msg covering string, descriptor, template, and invalid inputs
- run tests via tsx using node:test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1a8c383bc832fb910cdc0155b68c9