### PR TITLE
feat: support template params and restrict dynamic strings

### DIFF
--- a/packages/translate/test/msg.test.ts
+++ b/packages/translate/test/msg.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { msg } from '../src/index.ts';
+import { msg, Translator } from '../src/index.ts';
 
 test('msg with string returns id and message', () => {
   assert.deepEqual(msg('hello'), { id: 'hello', message: 'hello' });
@@ -21,12 +21,41 @@ test('msg with descriptor message only uses it for id too', () => {
   assert.deepEqual(msg(descriptor), { id: 'onlyMessage', message: 'onlyMessage' });
 });
 
-test('msg with template string returns composed id and message', () => {
+test('msg with template string returns placeholders and values', () => {
   const name = 'World';
   assert.deepEqual(msg`Hello, ${name}!`, {
-    id: 'Hello, World!',
-    message: 'Hello, World!',
+    id: 'Hello, ${0}!',
+    message: 'Hello, ${0}!',
+    values: [name],
   });
+});
+
+test('translator substitutes template values', () => {
+  const name = 'World';
+  const t = new Translator('en', {});
+  assert.equal(t.gettext(msg`Hello, ${name}!`), 'Hello, World!');
+});
+
+test('translator applies translations with placeholders', () => {
+  const name = 'World';
+  const translations = {
+    ru: {
+      translations: {
+        '': {
+          'Hello, ${0}!': { msgid: 'Hello, ${0}!', msgstr: ['Привет, ${0}!'] },
+        },
+      },
+    },
+  } as any;
+  const t = new Translator('en', translations);
+  t.useLocale('ru');
+  assert.equal(t.gettext(msg`Hello, ${name}!`), 'Привет, World!');
+});
+
+test('msg disallows computed strings', () => {
+  const variable: string = 'v';
+  // @ts-expect-error computed strings are not allowed
+  msg('Computed' + variable + 'string');
 });
 
 test('msg with invalid argument throws', () => {


### PR DESCRIPTION
## Summary
- handle template literal parameters by retaining placeholders
- replace placeholders with runtime values during translation
- prevent calling `msg` with computed strings via type restriction

## Testing
- `npm test --workspace @let-value/translate`
- `npm test` *(fails: Cannot find package 'gettext-parser' imported from packages/export)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ab52017c832fb0cf9500f4e69f1f