### PR TITLE
Add plural form support with ngettext

### DIFF
--- a/packages/translate/src/translator.ts
+++ b/packages/translate/src/translator.ts
@@ -1,7 +1,15 @@
-import { msg, isMessageId, MessageDescriptor, MessageId } from './utils.ts';
+import {
+  msg,
+  isMessageId,
+  isPluralMessage,
+  MessageDescriptor,
+  MessageId,
+  PluralMessage,
+} from './utils.ts';
 
 export interface TranslationEntry {
   msgid: string;
+  msgid_plural?: string;
   msgstr: string[];
 }
 
@@ -13,8 +21,32 @@ function substitute(text: string, values: any[] = []): string {
   return text.replace(/\$\{(\d+)\}/g, (_, i) => String(values[Number(i)]));
 }
 
+function parsePluralFunc(header?: string): (n: number) => number {
+  const defaultFn = (n: number) => (n !== 1 ? 1 : 0);
+  if (!header) return defaultFn;
+  const match = header.match(/Plural-Forms:\s*([^\n]*)/i);
+  if (!match) return defaultFn;
+  const nplMatch = match[1].match(/nplurals\s*=\s*(\d+)/);
+  const exprMatch = match[1].match(/plural\s*=\s*([^;]+)/);
+  const nplurals = nplMatch ? parseInt(nplMatch[1], 10) : 2;
+  const expr = exprMatch ? exprMatch[1] : 'n != 1';
+  let fn: (n: number) => number;
+  try {
+    fn = new Function('n', `return Number(${expr});`) as (n: number) => number;
+  } catch {
+    fn = defaultFn;
+  }
+  return (n: number) => {
+    const idx = fn(n);
+    if (idx < 0) return 0;
+    if (idx >= nplurals) return nplurals - 1;
+    return idx;
+  };
+}
+
 export class Translator {
   private locale: string;
+  private pluralFuncs: Record<string, (n: number) => number> = {};
   constructor(
     defaultLocale: string,
     private translations: Record<string, PoData>
@@ -38,5 +70,56 @@ export class Translator {
       localeData?.translations?.['']?.[message.id]?.msgstr?.[0];
     const result = translated && translated.length ? translated : message.message;
     return message.values ? substitute(result, message.values) : result;
+  }
+
+  private getPluralFunc(locale: string): (n: number) => number {
+    if (!this.pluralFuncs[locale]) {
+      const header = this.translations[locale]?.translations?.['']?.['']?.msgstr?.[0];
+      this.pluralFuncs[locale] = parsePluralFunc(header);
+    }
+    return this.pluralFuncs[locale];
+  }
+
+  ngettext(
+    plural: PluralMessage,
+    n: number,
+    ...values: any[]
+  ): string;
+  ngettext(
+    singular: MessageId | MessageDescriptor | string | TemplateStringsArray,
+    plural: MessageId | MessageDescriptor | string | TemplateStringsArray,
+    n: number,
+    ...values: any[]
+  ): string;
+  ngettext(...args: any[]): string {
+    let forms: MessageId[];
+    let n: number;
+    let vals: any[] = [];
+
+    if (isPluralMessage(args[0])) {
+      forms = args[0].forms;
+      n = args[1];
+      vals = args.slice(2);
+    } else {
+      const sing = isMessageId(args[0])
+        ? args[0]
+        : msg(args[0] as any, ...args.slice(3));
+      const plur = isMessageId(args[1])
+        ? args[1]
+        : msg(args[1] as any, ...args.slice(3));
+      forms = [sing, plur];
+      n = args[2];
+      vals = args.slice(3);
+    }
+
+    const localeData = this.translations[this.locale];
+    const entry = localeData?.translations?.['']?.[forms[0].id];
+    const pluralFunc = this.getPluralFunc(this.locale);
+    const index = pluralFunc(n);
+    const translated = entry?.msgstr?.[index];
+    const defaultForm = forms[index] ?? forms[forms.length - 1];
+    const result = translated && translated.length ? translated : defaultForm.message;
+    const usedVals = forms.find((f) => f.values)?.values ?? vals;
+    return usedVals && usedVals.length ? substitute(result, usedVals) : result;
   }
 }

--- a/packages/translate/src/utils.ts
+++ b/packages/translate/src/utils.ts
@@ -9,6 +9,10 @@ export interface MessageId {
   values?: any[];
 }
 
+export interface PluralMessage {
+  forms: MessageId[];
+}
+
 function buildFromTemplate(strings: TemplateStringsArray): string {
   let result = '';
   for (let i = 0; i < strings.length; i++) {
@@ -49,4 +53,17 @@ export function msg(arg: any, ...values: any[]): MessageId {
 
 export function isMessageId(obj: any): obj is MessageId {
   return obj && typeof obj === 'object' && 'id' in obj && 'message' in obj;
+}
+
+export function isPluralMessage(obj: any): obj is PluralMessage {
+  return obj && typeof obj === 'object' && Array.isArray(obj.forms);
+}
+
+export function plural(
+  ...forms: Array<MessageDescriptor | MessageId | string | TemplateStringsArray>
+): PluralMessage {
+  const messages = forms.map((f) =>
+    isMessageId(f) ? f : msg(f as any)
+  );
+  return { forms: messages };
 }

--- a/packages/translate/test/ngettext.test.ts
+++ b/packages/translate/test/ngettext.test.ts
@@ -1,0 +1,82 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { msg, plural } from '../src/utils.ts';
+import { Translator } from '../src/translator.ts';
+
+const translations = {
+  en: {
+    translations: {
+      '': {
+        '': {
+          msgid: '',
+          msgstr: ['Plural-Forms: nplurals=2; plural=(n != 1);\n'],
+        },
+        '${0} apple': {
+          msgid: '${0} apple',
+          msgid_plural: '${0} apples',
+          msgstr: ['${0} apple', '${0} apples'],
+        },
+      },
+    },
+  },
+  ru: {
+    translations: {
+      '': {
+        '': {
+          msgid: '',
+          msgstr: [
+            'Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n',
+          ],
+        },
+        '${0} apple': {
+          msgid: '${0} apple',
+          msgid_plural: '${0} apples',
+          msgstr: ['${0} яблоко', '${0} яблока', '${0} яблок'],
+        },
+      },
+    },
+  },
+} as any;
+
+test('ngettext handles English plurals', () => {
+  const t = new Translator('en', translations);
+  assert.equal(t.ngettext(msg`${1} apple`, msg`${1} apples`, 1), '1 apple');
+  assert.equal(t.ngettext(msg`${2} apple`, msg`${2} apples`, 2), '2 apples');
+});
+
+test('ngettext handles Russian plurals', () => {
+  const t = new Translator('en', translations);
+  t.useLocale('ru');
+  assert.equal(t.ngettext(msg`${1} apple`, msg`${1} apples`, 1), '1 яблоко');
+  assert.equal(t.ngettext(msg`${2} apple`, msg`${2} apples`, 2), '2 яблока');
+  assert.equal(t.ngettext(msg`${5} apple`, msg`${5} apples`, 5), '5 яблок');
+});
+
+test('ngettext supports plural helper', () => {
+  const t = new Translator('en', translations);
+  const apples = plural('${0} apple', '${0} apples');
+  assert.equal(t.ngettext(apples, 1, 1), '1 apple');
+  assert.equal(t.ngettext(apples, 2, 2), '2 apples');
+});
+
+test('ngettext supports plural helper with multiple forms', () => {
+  const t = new Translator('en', translations);
+  t.useLocale('ru');
+  const apples = plural('${0} apple', '${0} apples', '${0} many apples');
+  assert.equal(t.ngettext(apples, 1, 1), '1 яблоко');
+  assert.equal(t.ngettext(apples, 2, 2), '2 яблока');
+  assert.equal(t.ngettext(apples, 5, 5), '5 яблок');
+});
+
+test('ngettext handles deferred msg objects', () => {
+  const t = new Translator('en', translations);
+  const sing = msg('${0} apple');
+  const plur = msg('${0} apples');
+  assert.equal(t.ngettext(sing, plur, 3, 3), '3 apples');
+});
+
+test('ngettext works with plain strings', () => {
+  const t = new Translator('en', translations);
+  assert.equal(t.ngettext('${0} apple', '${0} apples', 1, 1), '1 apple');
+  assert.equal(t.ngettext('${0} apple', '${0} apples', 2, 2), '2 apples');
+});

--- a/packages/translate/test/plural.test.ts
+++ b/packages/translate/test/plural.test.ts
@@ -1,0 +1,12 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { plural } from '../src/utils.ts';
+
+test('plural supports arbitrary number of forms', () => {
+  const forms = plural('${0} apple', '${0} apples', '${0} many apples');
+  assert.equal(forms.forms.length, 3);
+  assert.equal(forms.forms[0].message, '${0} apple');
+  assert.equal(forms.forms[1].message, '${0} apples');
+  assert.equal(forms.forms[2].message, '${0} many apples');
+});
+


### PR DESCRIPTION
## Summary
- allow `plural` helper to accept any number of forms and expose them through `PluralMessage`
- update `Translator.ngettext` to select among multiple forms when building defaults
- add tests verifying plural helper structure and multi-form usage in Russian `ngettext`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1b7db88a4832fb9a9a5a0fe87b7d5