### PR TITLE
Add context-aware translation methods

### DIFF
--- a/packages/translate/test/fixtures/en.po
+++ b/packages/translate/test/fixtures/en.po
@@ -7,3 +7,17 @@ msgid "${0} apple"
 msgid_plural "${0} apples"
 msgstr[0] "${0} apple"
 msgstr[1] "${0} apples"
+
+msgctxt "verb"
+msgid "Open"
+msgstr[0] "Open"
+
+msgctxt "adjective"
+msgid "Open"
+msgstr[0] "Open"
+
+msgctxt "company"
+msgid "${0} apple"
+msgid_plural "${0} apples"
+msgstr[0] "${0} apple"
+msgstr[1] "${0} apples"

--- a/packages/translate/test/fixtures/ru.po
+++ b/packages/translate/test/fixtures/ru.po
@@ -11,3 +11,18 @@ msgstr[2] "${0} яблок"
 
 msgid "Hello, ${0}!"
 msgstr[0] "Привет, ${0}!"
+
+msgctxt "verb"
+msgid "Open"
+msgstr[0] "Открыть"
+
+msgctxt "adjective"
+msgid "Open"
+msgstr[0] "Открытый"
+
+msgctxt "company"
+msgid "${0} apple"
+msgid_plural "${0} apples"
+msgstr[0] "${0} Apple устройство"
+msgstr[1] "${0} Apple устройства"
+msgstr[2] "${0} Apple устройств"

--- a/packages/translate/test/ngettext.test.ts
+++ b/packages/translate/test/ngettext.test.ts
@@ -57,3 +57,16 @@ test('ngettext works with plain strings', () => {
   assert.equal(t.ngettext('${0} apple', '${0} apples', 1, 1), '1 apple');
   assert.equal(t.ngettext('${0} apple', '${0} apples', 2, 2), '2 apples');
 });
+
+test('npgettext handles context with plurals', () => {
+  const t = new Translator('en', translations);
+  t.useLocale('ru');
+  assert.equal(
+    t.npgettext('company', msg`${1} apple`, msg`${1} apples`, 1),
+    '1 Apple устройство'
+  );
+  assert.equal(
+    t.npgettext('company', msg`${2} apple`, msg`${2} apples`, 2),
+    '2 Apple устройства'
+  );
+});

--- a/packages/translate/test/translator.test.ts
+++ b/packages/translate/test/translator.test.ts
@@ -19,3 +19,12 @@ test('translator applies translations with placeholders', () => {
   t.useLocale('ru');
   assert.equal(t.gettext(msg`Hello, ${name}!`), 'Привет, World!');
 });
+
+test('pgettext handles context-specific translations', () => {
+  const ruPo = fs.readFileSync(new URL('./fixtures/ru.po', import.meta.url));
+  const translations = { ru: gettextParser.po.parse(ruPo) };
+  const t = new Translator('en', translations);
+  t.useLocale('ru');
+  assert.equal(t.pgettext('verb', 'Open'), 'Открыть');
+  assert.equal(t.pgettext('adjective', 'Open'), 'Открытый');
+});


### PR DESCRIPTION
## Summary
- refactor translator to index translations by context and cache plural headers
- add `pgettext` and `npgettext` for context-based singular and plural lookups
- test context resolution with identical msgids across different contexts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1c38d3d7c832fbe8b8a7a6f7a4646