### PR TITLE
Replace dynamic plural parsing with library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1487,6 +1487,9 @@
     "packages/translate": {
       "name": "@let-value/translate",
       "version": "1.0.0",
+      "dependencies": {
+        "plural-forms": "^0.5.5"
+      },
       "devDependencies": {
         "@types/gettext-parser": "^8.0.0",
         "gettext-parser": "^8.0.0",

--- a/packages/translate/package.json
+++ b/packages/translate/package.json
@@ -13,6 +13,9 @@
     "lint": "echo linting translate",
     "test": "tsx --test test/*.test.ts"
   },
+  "dependencies": {
+    "plural-forms": "^0.5.5"
+  },
   "devDependencies": {
     "@types/gettext-parser": "^8.0.0",
     "gettext-parser": "^8.0.0",


### PR DESCRIPTION
## Summary
- replace `parsePluralFunc` implementation with `plural-forms/minimal-safe`
- determine plural rules by locale instead of parsing headers
- add `plural-forms` dependency to translate package

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1cb2d891c832f9087f4564f968248