### PR TITLE
Handle distinct placeholders for plural forms

### DIFF
--- a/packages/translate/src/translator.ts
+++ b/packages/translate/src/translator.ts
@@ -38,12 +38,12 @@ export class Translator {
   }
 
   getPluralText({ forms, n }: PluralMessageId, msgctxt = ''): string {
-    const entry = this.translations[this.locale].translations?.[msgctxt]?.[forms[0].msgid];
+    const entry = this.translations[this.locale]?.translations?.[msgctxt]?.[forms[0].msgid];
     const index = pluralFunc(this.locale)(n);
-    const translated = entry.msgstr[index];
-    const defaultForm = forms[index] ?? forms[forms.length - 1];
-    const result = translated && translated.length ? translated : defaultForm.msgstr;
-    const usedVals = forms.find((f) => f.values)?.values;
+    const form = forms[index] ?? forms[forms.length - 1];
+    const translated = entry?.msgstr?.[index];
+    const result = translated && translated.length ? translated : form.msgstr;
+    const usedVals = form.values && form.values.length ? form.values : forms[0].values;
     return usedVals && usedVals.length ? substitute(result, usedVals) : result;
   }
 

--- a/packages/translate/test/ngettext.test.ts
+++ b/packages/translate/test/ngettext.test.ts
@@ -41,6 +41,18 @@ test('ngettext supports plural helper with multiple forms', () => {
   assert.equal(t.ngettext(apples), '5 яблок');
 });
 
+test('ngettext substitutes values from the chosen plural form', () => {
+  const t = new Translator('en', translations);
+  assert.equal(
+    t.ngettext(msg`${'Bob'} ${1} carrot`, msg`${2} carrots for ${'Bob'}`, 1),
+    'Bob 1 carrot',
+  );
+  assert.equal(
+    t.ngettext(msg`${'Bob'} ${1} carrot`, msg`${2} carrots for ${'Bob'}`, 2),
+    '2 carrots for Bob',
+  );
+});
+
 test('npgettext handles context with plurals', () => {
   const t = new Translator('ru', translations);
   assert.equal(

--- a/packages/translate/test/npgettext.test.ts
+++ b/packages/translate/test/npgettext.test.ts
@@ -34,3 +34,15 @@ test('pgettext and npgettext accept context-aware messages', () => {
     const apples = context('company').plural(msg`${3} apple`, msg`${3} apples`, 3);
     assert.equal(t.npgettext(apples), '3 Apple устройства');
 });
+
+test('npgettext substitutes values from the chosen plural form', () => {
+    const t = new Translator('en', translations);
+    assert.equal(
+        t.npgettext('ctx', msg`${1} apple`, msg`${2} apples for ${'Bob'}`, 1),
+        '1 apple',
+    );
+    assert.equal(
+        t.npgettext('ctx', msg`${1} apple`, msg`${2} apples for ${'Bob'}`, 2),
+        '2 apples for Bob',
+    );
+});


### PR DESCRIPTION
## Summary
- Ensure plural translations use values from the selected form, falling back to default values when needed
- Add tests covering plural forms with swapped placeholders

## Testing
- `npm test --workspaces --if-present`
- `npm run lint --workspaces --if-present`


------
https://chatgpt.com/codex/tasks/task_e_68b301718ddc832fb8681814193bb57d