### PR TITLE
test: verify translator fallbacks for missing translations

### DIFF
--- a/packages/translate/test/gettext.test.ts
+++ b/packages/translate/test/gettext.test.ts
@@ -19,3 +19,9 @@ test('translator applies translations with placeholders', () => {
   t.useLocale('ru');
   assert.equal(t.gettext`Hello, ${name}!`, 'Привет, World!');
 });
+
+test('gettext returns original string when translation missing', () => {
+  const t = new Translator('en', {});
+  t.useLocale('fr');
+  assert.equal(t.gettext(msg`Untranslated`), 'Untranslated');
+});

--- a/packages/translate/test/ngettext.test.ts
+++ b/packages/translate/test/ngettext.test.ts
@@ -70,3 +70,10 @@ test('ngettext handles context-aware plural helper', () => {
   const apples = context('company').plural(msg`${2} apple`, msg`${2} apples`, 2);
   assert.equal(t.npgettext(apples), '2 Apple устройства');
 });
+
+test('ngettext returns default forms when translation missing', () => {
+  const t = new Translator('en', {});
+  t.useLocale('fr');
+  assert.equal(t.ngettext(msg`${1} apple`, msg`${1} apples`, 1), '1 apple');
+  assert.equal(t.ngettext(msg`${2} apple`, msg`${2} apples`, 2), '2 apples');
+});

--- a/packages/translate/test/npgettext.test.ts
+++ b/packages/translate/test/npgettext.test.ts
@@ -46,3 +46,15 @@ test('npgettext substitutes values from the chosen plural form', () => {
         '2 apples for Bob',
     );
 });
+
+test('npgettext returns default forms when translation missing', () => {
+    const t = new Translator('ru', translations);
+    assert.equal(
+        t.npgettext('company', msg`${1} pear`, msg`${1} pears`, 1),
+        '1 pear',
+    );
+    assert.equal(
+        t.npgettext('company', msg`${2} pear`, msg`${2} pears`, 2),
+        '2 pears',
+    );
+});

--- a/packages/translate/test/pgettext.test.ts
+++ b/packages/translate/test/pgettext.test.ts
@@ -21,3 +21,10 @@ test('gettext handles context-aware messages', () => {
   const verb = context('verb');
   assert.equal(t.pgettext(verb.msg('Open')), 'Открыть');
 });
+
+test('pgettext returns original string when translation missing', () => {
+  const ruPo = fs.readFileSync(new URL('./fixtures/ru.po', import.meta.url));
+  const translations = { ru: gettextParser.po.parse(ruPo) };
+  const t = new Translator('ru', translations);
+  assert.equal(t.pgettext('verb', 'Close'), 'Close');
+});


### PR DESCRIPTION
## Summary
- add tests for gettext, ngettext, pgettext, and npgettext when translations are missing
- ensure fallback to original message or plural form

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3e4c9ddac832f87fb89fad8f0247c