### PR TITLE
Add tests for utility helpers

### DIFF
--- a/packages/translate/test/utils.test.ts
+++ b/packages/translate/test/utils.test.ts
@@ -1,0 +1,30 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { substitute, memo, pluralFunc } from '../src/utils.ts';
+
+
+// substitute replacement behavior
+test('substitute replaces placeholders with values', () => {
+  assert.equal(substitute('Hello ${0}, ${1}!', ['World', 'Friend']), 'Hello World, Friend!');
+});
+
+// memo caching behavior
+test('memo caches results for same inputs', () => {
+  let calls = 0;
+  const fn = memo((x: number) => {
+    calls++;
+    return x * 2;
+  });
+
+  assert.equal(fn(2), 4);
+  assert.equal(fn(2), 4);
+  assert.equal(calls, 1);
+});
+
+// pluralFunc default behavior for unknown locale
+test('pluralFunc falls back to default when locale is unknown', () => {
+  const pf = pluralFunc('xx');
+  assert.equal(pf(1), 0);
+  assert.equal(pf(2), 1);
+});


### PR DESCRIPTION
## Summary
- test substitute replaces placeholders
- verify memo caches results for repeated inputs
- ensure pluralFunc falls back to default for unknown locales

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3e6f528bc832fb511a89cd610bc82