### PR TITLE
Refactor extractor into modular library

### DIFF
--- a/packages/extract/bin/cli.ts
+++ b/packages/extract/bin/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import fs from 'node:fs';
-import { extractToPo } from '../src/index';
+import { extractPo } from '../src/index';
 
 const [, , entry, locale = 'en', out] = process.argv;
 if (!entry) {
@@ -8,7 +8,7 @@ if (!entry) {
   process.exit(1);
 }
 
-const po = extractToPo(entry, locale);
+const po = extractPo(entry, locale);
 if (out) {
   fs.writeFileSync(out, po);
 } else {

--- a/packages/extract/src/index.ts
+++ b/packages/extract/src/index.ts
@@ -1,126 +1,41 @@
-import { parseSync } from 'oxc-parser';
-import resolver from 'oxc-resolver';
-import * as gettextParser from 'gettext-parser';
-import { getFormula, getNPlurals } from 'plural-forms';
-import fs from 'node:fs';
 import path from 'node:path';
+import { parseFile, RawMessage } from './parse';
+import { resolveImports } from './walk';
+import { collect as collectImpl, buildPo as buildPoImpl } from './po';
 
-type Node = Record<string, any> | null | undefined;
-type Visitors = Record<string, (node: Node) => void>;
+export { parseFile } from './parse';
+export type { RawMessage, ParseResult } from './parse';
+export { resolveImports } from './walk';
+export { collect, buildPo } from './po';
+export type { Message } from './po';
 
-function walk(node: Node, visitors: Visitors): void {
-  if (!node || typeof node !== 'object') return;
-  const visit = visitors[(node as any).type];
-  if (visit) visit(node);
-  for (const key of Object.keys(node)) {
-    const value = (node as any)[key];
-    if (Array.isArray(value)) {
-      for (const child of value) walk(child, visitors);
-    } else if (value && typeof (value as any).type === 'string') {
-      walk(value, visitors);
+/** Walk the dependency graph starting from entry and collect raw messages. */
+export function extract(entry: string): RawMessage[] {
+  const queue = [path.resolve(entry)];
+  const visited = new Set<string>();
+  const all: RawMessage[] = [];
+
+  while (queue.length) {
+    const file = queue.shift()!;
+    if (visited.has(file)) continue;
+    visited.add(file);
+
+    const { messages, imports } = parseFile(file);
+    all.push(...messages);
+
+    const resolved = resolveImports(file, imports);
+    for (const next of resolved) {
+      if (!visited.has(next)) queue.push(next);
     }
   }
+
+  return all;
 }
 
-export interface Message {
-  msgid: string;
-  references: string[];
-  comments: string[];
-}
-
-interface RawMessage {
-  msgid: string;
-  reference: string;
-  comment?: string;
-}
-
-function extractFromFile(
-  filePath: string,
-  visited: Set<string> = new Set()
-): RawMessage[] {
-  const absPath = path.resolve(filePath);
-  if (visited.has(absPath)) return [];
-  visited.add(absPath);
-  const source = fs.readFileSync(absPath, 'utf8');
-  const lines = source.split(/\r?\n/);
-  const ast = parseSync(absPath, source).program as Node;
-  const messages: RawMessage[] = [];
-
-  walk(ast, {
-    CallExpression(node) {
-      const callee = (node as any).callee;
-      if (
-        callee &&
-        callee.type === 'Identifier' &&
-        (callee.name === 't' || callee.name === 'ngettext')
-      ) {
-        const arg = (node as any).arguments[0];
-        if (arg && arg.type === 'Literal' && typeof arg.value === 'string') {
-          const loc = (node as any).loc?.start;
-          const line = loc?.line ?? 1;
-          const rel = path.relative(process.cwd(), absPath);
-          const reference = `${rel}:${line}`;
-          const prev = lines[line - 2]?.trim();
-          const comment = prev && prev.startsWith('//') ? prev.slice(2).trim() : undefined;
-          messages.push({ msgid: arg.value, reference, comment });
-        }
-      }
-    },
-    ImportDeclaration(node) {
-      const spec = (node as any).source.value as string;
-      const result = resolver.sync(path.dirname(absPath), spec) as { path?: string };
-      if (result.path) {
-        messages.push(...extractFromFile(result.path, visited));
-      }
-    }
-  });
-
-  return messages;
-}
-
-export function extract(entry: string): Message[] {
-  const raw = extractFromFile(entry);
-  const map = new Map<string, Message>();
-  for (const m of raw) {
-    if (!map.has(m.msgid)) {
-      map.set(m.msgid, { msgid: m.msgid, references: [], comments: [] });
-    }
-    const entryMsg = map.get(m.msgid)!;
-    entryMsg.references.push(m.reference);
-    if (m.comment) entryMsg.comments.push(m.comment);
-  }
-  return Array.from(map.values());
-}
-
-export function buildPo(locale: string, messages: Message[]): string {
-  const headers = {
-    'content-type': 'text/plain; charset=UTF-8',
-    'plural-forms': `nplurals=${getNPlurals(locale)}; plural=${getFormula(locale)};`,
-    language: locale
-  } as Record<string, string>;
-
-  const poObj: any = {
-    charset: 'utf-8',
-    headers,
-    translations: { '': {} as Record<string, any> }
-  };
-
-  for (const m of messages) {
-    poObj.translations[''][m.msgid] = {
-      msgid: m.msgid,
-      msgstr: [''],
-      references: m.references.join('\n'),
-      comments: m.comments.length
-        ? { extracted: m.comments.join('\n') }
-        : undefined
-    };
-  }
-
-  return gettextParser.po.compile(poObj).toString();
-}
-
-export function extractToPo(entry: string, locale: string): string {
-  const messages = extract(entry);
-  return buildPo(locale, messages);
+/** Convenience function to collect and build a PO file. */
+export function extractPo(entry: string, locale: string): string {
+  const raw = extract(entry);
+  const messages = collectImpl(raw);
+  return buildPoImpl(locale, messages);
 }
 

--- a/packages/extract/src/parse.ts
+++ b/packages/extract/src/parse.ts
@@ -1,0 +1,76 @@
+import { parseSync } from 'oxc-parser';
+import fs from 'node:fs';
+import path from 'node:path';
+
+// Generic AST node type from oxc
+export type Node = Record<string, any> | null | undefined;
+export type Visitors = Record<string, (node: Node) => void>;
+
+function walk(node: Node, visitors: Visitors): void {
+  if (!node || typeof node !== 'object') return;
+  const visit = visitors[(node as any).type];
+  if (visit) visit(node);
+  for (const key of Object.keys(node)) {
+    const value = (node as any)[key];
+    if (Array.isArray(value)) {
+      for (const child of value) walk(child, visitors);
+    } else if (value && typeof (value as any).type === 'string') {
+      walk(value, visitors);
+    }
+  }
+}
+
+export interface RawMessage {
+  msgid: string;
+  reference: string;
+  comment?: string;
+}
+
+export interface ParseResult {
+  messages: RawMessage[];
+  imports: string[];
+}
+
+/**
+ * Parse a single JavaScript/TypeScript file and collect translation messages
+ * defined via t()/ngettext() calls. Returns the messages and the raw import
+ * specifiers found in the file.
+ */
+export function parseFile(filePath: string): ParseResult {
+  const absPath = path.resolve(filePath);
+  const source = fs.readFileSync(absPath, 'utf8');
+  const lines = source.split(/\r?\n/);
+  const ast = parseSync(absPath, source).program as Node;
+
+  const messages: RawMessage[] = [];
+  const imports: string[] = [];
+
+  walk(ast, {
+    CallExpression(node) {
+      const callee = (node as any).callee;
+      if (
+        callee &&
+        callee.type === 'Identifier' &&
+        (callee.name === 't' || callee.name === 'ngettext')
+      ) {
+        const arg = (node as any).arguments[0];
+        if (arg && arg.type === 'Literal' && typeof arg.value === 'string') {
+          const loc = (node as any).loc?.start;
+          const line = loc?.line ?? 1;
+          const rel = path.relative(process.cwd(), absPath);
+          const reference = `${rel}:${line}`;
+          const prev = lines[line - 2]?.trim();
+          const comment = prev && prev.startsWith('//') ? prev.slice(2).trim() : undefined;
+          messages.push({ msgid: arg.value, reference, comment });
+        }
+      }
+    },
+    ImportDeclaration(node) {
+      const spec = (node as any).source.value as string;
+      imports.push(spec);
+    }
+  });
+
+  return { messages, imports };
+}
+

--- a/packages/extract/src/po.ts
+++ b/packages/extract/src/po.ts
@@ -1,0 +1,50 @@
+import * as gettextParser from 'gettext-parser';
+import { getFormula, getNPlurals } from 'plural-forms';
+import { RawMessage } from './parse';
+
+export interface Message {
+  msgid: string;
+  references: string[];
+  comments: string[];
+}
+
+/** Combine raw messages into unique translation messages. */
+export function collect(raw: RawMessage[]): Message[] {
+  const map = new Map<string, Message>();
+  for (const m of raw) {
+    if (!map.has(m.msgid)) {
+      map.set(m.msgid, { msgid: m.msgid, references: [], comments: [] });
+    }
+    const entry = map.get(m.msgid)!;
+    entry.references.push(m.reference);
+    if (m.comment) entry.comments.push(m.comment);
+  }
+  return Array.from(map.values());
+}
+
+/** Build a PO file string from messages and locale. */
+export function buildPo(locale: string, messages: Message[]): string {
+  const headers = {
+    'content-type': 'text/plain; charset=UTF-8',
+    'plural-forms': `nplurals=${getNPlurals(locale)}; plural=${getFormula(locale)};`,
+    language: locale
+  } as Record<string, string>;
+
+  const poObj: any = {
+    charset: 'utf-8',
+    headers,
+    translations: { '': {} as Record<string, any> }
+  };
+
+  for (const m of messages) {
+    poObj.translations[''][m.msgid] = {
+      msgid: m.msgid,
+      msgstr: [''],
+      references: m.references.join('\n'),
+      comments: m.comments.length ? { extracted: m.comments.join('\n') } : undefined
+    };
+  }
+
+  return gettextParser.po.compile(poObj).toString();
+}
+

--- a/packages/extract/src/walk.ts
+++ b/packages/extract/src/walk.ts
@@ -1,0 +1,22 @@
+import path from 'node:path';
+import resolver from 'oxc-resolver';
+
+/**
+ * Resolve a list of import specifiers relative to a file.
+ *
+ * @param file - Absolute or relative path to the importing file.
+ * @param imports - Raw import specifiers collected from that file.
+ * @returns Absolute paths to resolved modules.
+ */
+export function resolveImports(file: string, imports: string[]): string[] {
+  const dir = path.dirname(path.resolve(file));
+  const resolved: string[] = [];
+  for (const spec of imports) {
+    const res = resolver.sync(dir, spec) as { path?: string };
+    if (res.path) {
+      resolved.push(res.path);
+    }
+  }
+  return resolved;
+}
+

--- a/packages/extract/test.ts
+++ b/packages/extract/test.ts
@@ -6,25 +6,54 @@ import { execSync } from 'node:child_process';
 import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
 
+import { parseFile } from './src/parse';
+import { resolveImports } from './src/walk';
+import { collect, buildPo } from './src/po';
+import { extract, extractPo } from './src';
+
 const require = createRequire(import.meta.url);
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'translate-extract-'));
-fs.writeFileSync(
-  path.join(tmp, 'dep.js'),
-  "// World comment\n t('World');\n"
-);
+fs.writeFileSync(path.join(tmp, 'dep.js'), "// World comment\n t('World');\n");
 fs.writeFileSync(
   path.join(tmp, 'entry.js'),
   "import './dep.js';\n // Greeting\n t('Hello');\n",
 );
 
+const entry = path.join(tmp, 'entry.js');
+
+// parseFile should read only current file
+const parsed = parseFile(entry);
+assert.deepStrictEqual(parsed.messages.map(m => m.msgid), ['Hello']);
+assert.deepStrictEqual(parsed.imports, ['./dep.js']);
+
+// resolveImports should resolve import paths
+const resolved = resolveImports(entry, parsed.imports);
+assert.deepStrictEqual(resolved, [path.join(tmp, 'dep.js')]);
+
+// extract should walk dependency graph
+const walked = extract(entry);
+const messages = collect(walked);
+assert(messages.some(m => m.msgid === 'Hello'));
+assert(messages.some(m => m.msgid === 'World'));
+
+// buildPo should include all messages
+const po = buildPo('en', messages);
+assert(po.includes('Hello') && po.includes('World'));
+
+// convenience extractPo should work
+const po2 = extractPo(entry, 'en');
+assert(po2.includes('Hello') && po2.includes('World'));
+
+// CLI should output the same
 const cli = path.resolve(__dirname, 'bin/cli.ts');
 const tsx = require.resolve('tsx/cli');
 const output = execSync(`node ${tsx} ${cli} entry.js en`, {
   cwd: tmp,
   encoding: 'utf8'
 });
-assert(output.length > 0);
-console.log('extract test passed');
+assert(output.includes('Hello'));
+assert(output.includes('World'));
 
+console.log('extract tests passed');


### PR DESCRIPTION
## Summary
- isolate parser to return raw messages and import specifiers
- resolve import specifiers separately and traverse queue to gather files
- build PO output after walking dependency graph

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3f18578c0832f889671355def6513