### PR TITLE
feat(extract): add msg query

### DIFF
--- a/packages/extract/src/queries/index.ts
+++ b/packages/extract/src/queries/index.ts
@@ -1,0 +1,12 @@
+import { tQuery } from './t';
+import { msgStringQuery, msgDescriptorQuery, msgTemplateQuery } from './msg';
+import type { QuerySpec } from './types';
+
+export type { QuerySpec, MessageMatch } from './types';
+
+export const messageQueries: QuerySpec[] = [
+  msgStringQuery,
+  msgDescriptorQuery,
+  msgTemplateQuery,
+  tQuery,
+];

--- a/packages/extract/src/queries/msg.ts
+++ b/packages/extract/src/queries/msg.ts
@@ -1,0 +1,65 @@
+import type { QuerySpec } from './types';
+
+export const msgStringQuery: QuerySpec = {
+  pattern: `(
+    (call_expression
+      function: (identifier) @func
+      arguments: (arguments (string (string_fragment) @msgid))
+    ) @call
+    (#match? @func "^msg$")
+  )`,
+  extract(match) {
+    const call = match.captures.find(c => c.name === 'call')!.node;
+    const msgid = match.captures.find(c => c.name === 'msgid')!.node.text;
+    return [{ node: call, msgid }];
+  },
+};
+
+export const msgDescriptorQuery: QuerySpec = {
+  pattern: `(
+    (call_expression
+      function: (identifier) @func
+      arguments: (arguments
+        (object
+          (_)*
+          (pair
+            key: (property_identifier) @id_key
+            value: (string (string_fragment) @id)
+            (#eq? @id_key "id")
+          )?
+          (_)*
+          (pair
+            key: (property_identifier) @msg_key
+            value: (string (string_fragment) @message)
+            (#eq? @msg_key "message")
+          )?
+          (_)*
+        )
+      )
+    ) @call
+    (#match? @func "^msg$")
+  )`,
+  extract(match) {
+    const call = match.captures.find(c => c.name === 'call')!.node;
+    const id = match.captures.find(c => c.name === 'id')?.node.text;
+    const message = match.captures.find(c => c.name === 'message')?.node.text;
+    const msgid = id ?? message;
+    return msgid ? [{ node: call, msgid }] : [];
+  },
+};
+
+export const msgTemplateQuery: QuerySpec = {
+  pattern: `(
+    (call_expression
+      function: (identifier) @func
+      arguments: (template_string) @tpl
+    ) @call
+    (#match? @func "^msg$")
+  )`,
+  extract(match) {
+    const call = match.captures.find(c => c.name === 'call')!.node;
+    const tpl = match.captures.find(c => c.name === 'tpl')!.node;
+    const text = tpl.text.slice(1, -1);
+    return [{ node: call, msgid: text }];
+  },
+};

--- a/packages/extract/src/queries/t.ts
+++ b/packages/extract/src/queries/t.ts
@@ -1,0 +1,16 @@
+import type { QuerySpec, MessageMatch } from './types';
+
+export const tQuery: QuerySpec = {
+  pattern: `(
+    (call_expression
+      function: (identifier) @func
+      arguments: (arguments (string (string_fragment) @msgid))
+    ) @call
+    (#match? @func "^(t|ngettext)$")
+  )`,
+  extract(match) {
+    const call = match.captures.find(c => c.name === 'call')!.node;
+    const msgidNode = match.captures.find(c => c.name === 'msgid')!.node;
+    return [{ node: call, msgid: msgidNode.text }];
+  }
+};

--- a/packages/extract/src/queries/types.ts
+++ b/packages/extract/src/queries/types.ts
@@ -1,0 +1,11 @@
+import type Parser from 'tree-sitter';
+
+export interface MessageMatch {
+  node: Parser.SyntaxNode;
+  msgid: string;
+}
+
+export interface QuerySpec {
+  pattern: string;
+  extract(match: Parser.QueryMatch): MessageMatch[];
+}

--- a/packages/extract/test.ts
+++ b/packages/extract/test.ts
@@ -56,4 +56,25 @@ const output = execSync(`node ${tsx} ${cli} entry.js en`, {
 assert(output.includes('Hello'));
 assert(output.includes('World'));
 
+// msg query should extract various message forms
+const tmpMsg = fs.mkdtempSync(path.join(os.tmpdir(), 'translate-msg-'));
+fs.writeFileSync(
+  path.join(tmpMsg, 'entry.js'),
+  `
+msg('hello');
+msg({ id: 'greeting', message: 'Hello world' });
+msg({ id: 'onlyId' });
+msg({ message: 'onlyMessage' });
+msg\`Hello!\`;
+const name = "World";
+msg\`Hello, \${name}!\`;
+`,
+);
+
+const parsedMsg = parseFile(path.join(tmpMsg, 'entry.js'));
+assert.deepStrictEqual(
+  parsedMsg.messages.map(m => m.msgid).sort(),
+  ['hello', 'greeting', 'onlyId', 'onlyMessage', 'Hello!', 'Hello, ${name}!'].sort(),
+);
+
 console.log('extract tests passed');


### PR DESCRIPTION
## Summary
- refactor parse to run composable tree-sitter queries
- add msg query supporting strings, descriptors and templates
- cover msg extraction with tests
- split msg query into string, descriptor and template variants

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b41c88d368832faa6e89e4f85f4e70