### PR TITLE
feat: enrich msg query parsing with gettext types

### DIFF
--- a/packages/extract/src/index.ts
+++ b/packages/extract/src/index.ts
@@ -1,19 +1,21 @@
 import path from 'node:path';
-import { parseFile, RawMessage } from './parse';
+import { parseFile } from './parse';
 import { resolveImports } from './walk';
 import { collect as collectImpl, buildPo as buildPoImpl } from './po';
+import type { GetTextTranslation } from 'gettext-parser';
+import type { ParseResult } from './parse';
 
 export { parseFile } from './parse';
-export type { RawMessage, ParseResult } from './parse';
+export type { ParseResult } from './parse';
 export { resolveImports } from './walk';
 export { collect, buildPo } from './po';
 export type { Message } from './po';
 
 /** Walk the dependency graph starting from entry and collect raw messages. */
-export function extract(entry: string): RawMessage[] {
+export function extract(entry: string): GetTextTranslation[] {
   const queue = [path.resolve(entry)];
   const visited = new Set<string>();
-  const all: RawMessage[] = [];
+  const all: GetTextTranslation[] = [];
 
   while (queue.length) {
     const file = queue.shift()!;

--- a/packages/extract/src/po.ts
+++ b/packages/extract/src/po.ts
@@ -1,23 +1,25 @@
 import * as gettextParser from 'gettext-parser';
 import { getFormula, getNPlurals } from 'plural-forms';
-import { RawMessage } from './parse';
+import type { GetTextTranslation } from 'gettext-parser';
 
 export interface Message {
   msgid: string;
+  msgstr: string[];
   references: string[];
   comments: string[];
 }
 
 /** Combine raw messages into unique translation messages. */
-export function collect(raw: RawMessage[]): Message[] {
+export function collect(raw: GetTextTranslation[]): Message[] {
   const map = new Map<string, Message>();
   for (const m of raw) {
     if (!map.has(m.msgid)) {
-      map.set(m.msgid, { msgid: m.msgid, references: [], comments: [] });
+      map.set(m.msgid, { msgid: m.msgid, msgstr: [], references: [], comments: [] });
     }
     const entry = map.get(m.msgid)!;
-    entry.references.push(m.reference);
-    if (m.comment) entry.comments.push(m.comment);
+    if (entry.msgstr.length === 0 && m.msgstr.length) entry.msgstr = m.msgstr;
+    if (m.comments?.reference) entry.references.push(m.comments.reference);
+    if (m.comments?.extracted) entry.comments.push(m.comments.extracted);
   }
   return Array.from(map.values());
 }
@@ -39,7 +41,7 @@ export function buildPo(locale: string, messages: Message[]): string {
   for (const m of messages) {
     poObj.translations[''][m.msgid] = {
       msgid: m.msgid,
-      msgstr: [''],
+      msgstr: m.msgstr.length ? m.msgstr : [''],
       references: m.references.join('\n'),
       comments: m.comments.length ? { extracted: m.comments.join('\n') } : undefined
     };

--- a/packages/extract/src/queries/helpers.ts
+++ b/packages/extract/src/queries/helpers.ts
@@ -1,0 +1,4 @@
+export const withLeadingComment = (pattern: string): string => `(
+  ((comment) @comment .)?
+  (expression_statement ${pattern})
+)`;

--- a/packages/extract/src/queries/index.ts
+++ b/packages/extract/src/queries/index.ts
@@ -1,10 +1,11 @@
 import { tQuery } from './t';
-import { msgStringQuery, msgDescriptorQuery, msgTemplateQuery } from './msg';
+import { msgStringQuery, msgStringPairQuery, msgDescriptorQuery, msgTemplateQuery } from './msg';
 import type { QuerySpec } from './types';
 
 export type { QuerySpec, MessageMatch } from './types';
 
 export const messageQueries: QuerySpec[] = [
+  msgStringPairQuery,
   msgStringQuery,
   msgDescriptorQuery,
   msgTemplateQuery,

--- a/packages/extract/src/queries/msg.ts
+++ b/packages/extract/src/queries/msg.ts
@@ -1,65 +1,77 @@
 import type { QuerySpec } from './types';
+import { withLeadingComment } from './helpers';
+
+const msgCall = (args: string) => `(
+  (call_expression
+    function: (identifier) @func
+    arguments: ${args}
+  ) @call
+  (#match? @func "^msg$")
+)`;
 
 export const msgStringQuery: QuerySpec = {
-  pattern: `(
-    (call_expression
-      function: (identifier) @func
-      arguments: (arguments (string (string_fragment) @msgid))
-    ) @call
-    (#match? @func "^msg$")
-  )`,
+  pattern: withLeadingComment(msgCall(`(arguments
+    (string (string_fragment) @msgid)
+  )`)),
   extract(match) {
     const call = match.captures.find(c => c.name === 'call')!.node;
     const msgid = match.captures.find(c => c.name === 'msgid')!.node.text;
-    return [{ node: call, msgid }];
+    const comment = match.captures.find(c => c.name === 'comment')?.node;
+    return [{ node: call, translation: { msgid, msgstr: [] }, comment }];
+  },
+};
+
+export const msgStringPairQuery: QuerySpec = {
+  pattern: withLeadingComment(msgCall(`(arguments
+    (string (string_fragment) @msgid)
+    (string (string_fragment) @msgstr)
+  )`)),
+  extract(match) {
+    const call = match.captures.find(c => c.name === 'call')!.node;
+    const msgid = match.captures.find(c => c.name === 'msgid')!.node.text;
+    const msgstrNode = match.captures.find(c => c.name === 'msgstr')!.node.text;
+    const comment = match.captures.find(c => c.name === 'comment')?.node;
+    return [{ node: call, translation: { msgid, msgstr: [msgstrNode] }, comment }];
   },
 };
 
 export const msgDescriptorQuery: QuerySpec = {
-  pattern: `(
-    (call_expression
-      function: (identifier) @func
-      arguments: (arguments
-        (object
-          (_)*
-          (pair
-            key: (property_identifier) @id_key
-            value: (string (string_fragment) @id)
-            (#eq? @id_key "id")
-          )?
-          (_)*
-          (pair
-            key: (property_identifier) @msg_key
-            value: (string (string_fragment) @message)
-            (#eq? @msg_key "message")
-          )?
-          (_)*
-        )
-      )
-    ) @call
-    (#match? @func "^msg$")
-  )`,
+  pattern: withLeadingComment(msgCall(`(arguments
+    (object
+      (_)*
+      (pair
+        key: (property_identifier) @id_key
+        value: (string (string_fragment) @id)
+        (#eq? @id_key "id")
+      )?
+      (_)*
+      (pair
+        key: (property_identifier) @msg_key
+        value: (string (string_fragment) @message)
+        (#eq? @msg_key "message")
+      )?
+      (_)*
+    )
+  )`)),
   extract(match) {
     const call = match.captures.find(c => c.name === 'call')!.node;
     const id = match.captures.find(c => c.name === 'id')?.node.text;
     const message = match.captures.find(c => c.name === 'message')?.node.text;
     const msgid = id ?? message;
-    return msgid ? [{ node: call, msgid }] : [];
+    if (!msgid) return [];
+    const msgstr = id && message ? [message] : [];
+    const comment = match.captures.find(c => c.name === 'comment')?.node;
+    return [{ node: call, translation: { msgid, msgstr }, comment }];
   },
 };
 
 export const msgTemplateQuery: QuerySpec = {
-  pattern: `(
-    (call_expression
-      function: (identifier) @func
-      arguments: (template_string) @tpl
-    ) @call
-    (#match? @func "^msg$")
-  )`,
+  pattern: withLeadingComment(msgCall(`(template_string) @tpl`)),
   extract(match) {
     const call = match.captures.find(c => c.name === 'call')!.node;
     const tpl = match.captures.find(c => c.name === 'tpl')!.node;
     const text = tpl.text.slice(1, -1);
-    return [{ node: call, msgid: text }];
+    const comment = match.captures.find(c => c.name === 'comment')?.node;
+    return [{ node: call, translation: { msgid: text, msgstr: [] }, comment }];
   },
 };

--- a/packages/extract/src/queries/t.ts
+++ b/packages/extract/src/queries/t.ts
@@ -1,16 +1,20 @@
-import type { QuerySpec, MessageMatch } from './types';
+import type { QuerySpec } from './types';
+import { withLeadingComment } from './helpers';
+
+const callPattern = `(
+  (call_expression
+    function: (identifier) @func
+    arguments: (arguments (string (string_fragment) @msgid))
+  ) @call
+  (#match? @func "^(t|ngettext)$")
+)`;
 
 export const tQuery: QuerySpec = {
-  pattern: `(
-    (call_expression
-      function: (identifier) @func
-      arguments: (arguments (string (string_fragment) @msgid))
-    ) @call
-    (#match? @func "^(t|ngettext)$")
-  )`,
+  pattern: withLeadingComment(callPattern),
   extract(match) {
     const call = match.captures.find(c => c.name === 'call')!.node;
     const msgidNode = match.captures.find(c => c.name === 'msgid')!.node;
-    return [{ node: call, msgid: msgidNode.text }];
+    const comment = match.captures.find(c => c.name === 'comment')?.node;
+    return [{ node: call, translation: { msgid: msgidNode.text, msgstr: [] }, comment }];
   }
 };

--- a/packages/extract/src/queries/types.ts
+++ b/packages/extract/src/queries/types.ts
@@ -1,8 +1,10 @@
 import type Parser from 'tree-sitter';
+import type { GetTextTranslation } from 'gettext-parser';
 
 export interface MessageMatch {
   node: Parser.SyntaxNode;
-  msgid: string;
+  translation: GetTextTranslation;
+  comment?: Parser.SyntaxNode;
 }
 
 export interface QuerySpec {


### PR DESCRIPTION
## Summary
- capture optional leading comments in message queries
- surface captured comments in parsed translations
- test t() and msg() comment handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b42af83560832faf5ba2e84c480688