### PR TITLE
chore: replace oxlint with biome

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
+  "formatter": {
+    "enabled": true
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -4,10 +4,10 @@
     "": {
       "name": "translate",
       "devDependencies": {
+        "@biomejs/biome": "catalog:",
         "@types/gettext-parser": "catalog:",
         "gettext-parser": "catalog:",
         "oxc-resolver": "catalog:",
-        "oxlint": "catalog:",
         "plural-forms": "catalog:",
         "tree-sitter": "catalog:",
         "tree-sitter-javascript": "catalog:",
@@ -31,8 +31,8 @@
         "tree-sitter-typescript": "catalog:",
       },
       "devDependencies": {
+        "@biomejs/biome": "catalog:",
         "@types/gettext-parser": "catalog:",
-        "oxlint": "catalog:",
         "tsx": "catalog:",
         "typescript": "catalog:",
       },
@@ -44,19 +44,19 @@
         "plural-forms": "catalog:",
       },
       "devDependencies": {
+        "@biomejs/biome": "catalog:",
         "@types/gettext-parser": "catalog:",
         "gettext-parser": "catalog:",
-        "oxlint": "catalog:",
         "tsx": "catalog:",
         "typescript": "catalog:",
       },
     },
   },
   "catalog": {
+    "@biomejs/biome": "2.2.2",
     "@types/gettext-parser": "8.0.0",
     "gettext-parser": "8.0.0",
     "oxc-resolver": "11.7.1",
-    "oxlint": "1.13.0",
     "plural-forms": "0.5.5",
     "tree-sitter": "0.25.0",
     "tree-sitter-javascript": "0.23.1",
@@ -65,6 +65,24 @@
     "typescript": "5.9.2",
   },
   "packages": {
+    "@biomejs/biome": ["@biomejs/biome@2.2.2", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.2.2", "@biomejs/cli-darwin-x64": "2.2.2", "@biomejs/cli-linux-arm64": "2.2.2", "@biomejs/cli-linux-arm64-musl": "2.2.2", "@biomejs/cli-linux-x64": "2.2.2", "@biomejs/cli-linux-x64-musl": "2.2.2", "@biomejs/cli-win32-arm64": "2.2.2", "@biomejs/cli-win32-x64": "2.2.2" }, "bin": { "biome": "bin/biome" } }, "sha512-j1omAiQWCkhuLgwpMKisNKnsM6W8Xtt1l0WZmqY/dFj8QPNkIoTvk4tSsi40FaAAkBE1PU0AFG2RWFBWenAn+w=="],
+
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.2.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-6ePfbCeCPryWu0CXlzsWNZgVz/kBEvHiPyNpmViSt6A2eoDf4kXs3YnwQPzGjy8oBgQulrHcLnJL0nkCh80mlQ=="],
+
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.2.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-Tn4JmVO+rXsbRslml7FvKaNrlgUeJot++FkvYIhl1OkslVCofAtS35MPlBMhXgKWF9RNr9cwHanrPTUUXcYGag=="],
+
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.2.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-JfrK3gdmWWTh2J5tq/rcWCOsImVyzUnOS2fkjhiYKCQ+v8PqM+du5cfB7G1kXas+7KQeKSWALv18iQqdtIMvzw=="],
+
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.2.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-/MhYg+Bd6renn6i1ylGFL5snYUn/Ct7zoGVKhxnro3bwekiZYE8Kl39BSb0MeuqM+72sThkQv4TnNubU9njQRw=="],
+
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.2.2", "", { "os": "linux", "cpu": "x64" }, "sha512-Ogb+77edO5LEP/xbNicACOWVLt8mgC+E1wmpUakr+O4nKwLt9vXe74YNuT3T1dUBxC/SnrVmlzZFC7kQJEfquQ=="],
+
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.2.2", "", { "os": "linux", "cpu": "x64" }, "sha512-ZCLXcZvjZKSiRY/cFANKg+z6Fhsf9MHOzj+NrDQcM+LbqYRT97LyCLWy2AS+W2vP+i89RyRM+kbGpUzbRTYWig=="],
+
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.2.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-wBe2wItayw1zvtXysmHJQoQqXlTzHSpQRyPpJKiNIR21HzH/CrZRDFic1C1jDdp+zAPtqhNExa0owKMbNwW9cQ=="],
+
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.2.2", "", { "os": "win32", "cpu": "x64" }, "sha512-DAuHhHekGfiGb6lCcsT4UyxQmVwQiBCBUMwVra/dcOSs9q8OhfaZgey51MlekT3p8UwRqtXQfFuEJBhJNdLZwg=="],
+
     "@emnapi/core": ["@emnapi/core@1.5.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" } }, "sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.5.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ=="],
@@ -167,22 +185,6 @@
 
     "@oxc-resolver/binding-win32-x64-msvc": ["@oxc-resolver/binding-win32-x64-msvc@11.7.1", "", { "os": "win32", "cpu": "x64" }, "sha512-MXS81efp8pu2MkjEPu+nDhgoyHwdWUygXYSzIh3gV2A8/qF0PVEzH+EpmKR7Pl8dEZIaG1YXA+CO6bmNZT8oSw=="],
 
-    "@oxlint/darwin-arm64": ["@oxlint/darwin-arm64@1.13.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-evpsj1aaWNEd2VRGTbptiMwC8vYSDadAYtq92Ks3UIe0VoMtY9n5bLeD9Ctw/OHIM7Eh7/EQlNDLOOP/b2GBKA=="],
-
-    "@oxlint/darwin-x64": ["@oxlint/darwin-x64@1.13.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-a4gmSsuQq/ZK/QRDlAcfcwF4UVErZ3Q0noBkypyMdacizLzexlKQvWhXC5Bh1v4/9cWempx+Uf6iaScfo7FmCg=="],
-
-    "@oxlint/linux-arm64-gnu": ["@oxlint/linux-arm64-gnu@1.13.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-GT8WyPomb2AE5ciNzmDZlvVdYL2OmWObaV47dwAk4KH13IAqduOlA17S5IZRrwW1q4FHsRhfJ1eVofAhOtZexQ=="],
-
-    "@oxlint/linux-arm64-musl": ["@oxlint/linux-arm64-musl@1.13.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-EY8PHd4U0QYoPFVkGbkBPAN1ZDXmIr5Am6QOqnPtvrOVfR6cRW/o9Qd9Q3zB+HR+pEHl8d25/QSgHpaSQr+hEA=="],
-
-    "@oxlint/linux-x64-gnu": ["@oxlint/linux-x64-gnu@1.13.0", "", { "os": "linux", "cpu": "x64" }, "sha512-iP30520DYHsqAk3rmCJ4YpcNuWJejhbvl/YcHmrcWH8OJ5a+He2EG6gU9BogfFzsM1HtDn3pZbn69PItqaLJCg=="],
-
-    "@oxlint/linux-x64-musl": ["@oxlint/linux-x64-musl@1.13.0", "", { "os": "linux", "cpu": "x64" }, "sha512-SJl0aenYerXS6uFshdpsracwl02sr8dpUK1522p4Tp27aXHUxk55gF5YmFj9rGUQ9h6MyZgJL9fNS5U7PUUxxA=="],
-
-    "@oxlint/win32-arm64": ["@oxlint/win32-arm64@1.13.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-nAxRno4VF73obGWbBMMslWDYx0hFgqwKR7wqhhVowH5793p1tHvYbV9lrUY8lRqMUHRpYP4pahcipoAEiTlf1w=="],
-
-    "@oxlint/win32-x64": ["@oxlint/win32-x64@1.13.0", "", { "os": "win32", "cpu": "x64" }, "sha512-8p6OwSl6/iauD5TZrTXXZFdKZkj1blGwMOlhnHfSb6FRcjcvR6dv54u3PYssrtqh7nvHLJI0PAwSeJVhvoxxqg=="],
-
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-VyyPYFlOMNylG45GoAe0xDoLwWuowvf92F9kySqzYh8vmYm7D2u4iUJKa1tOUpS70Ku13ASrOkS4ScXFsTaCNQ=="],
 
     "@types/gettext-parser": ["@types/gettext-parser@8.0.0", "", { "dependencies": { "@types/node": "*", "@types/readable-stream": "*" } }, "sha512-oBBIahfWKqAC8LsIw+uFwhXfwlF8GhWDUhyEjoP7Pl9g5bFLhYA/2SiXPkE4oKhDX9fL091qCAyPVZtIkd5X6Q=="],
@@ -224,8 +226,6 @@
     "node-gyp-build": ["node-gyp-build@4.8.4", "", { "bin": { "node-gyp-build": "bin.js", "node-gyp-build-optional": "optional.js", "node-gyp-build-test": "build-test.js" } }, "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ=="],
 
     "oxc-resolver": ["oxc-resolver@11.7.1", "", { "dependencies": { "napi-postinstall": "^0.3.0" }, "optionalDependencies": { "@oxc-resolver/binding-android-arm-eabi": "11.7.1", "@oxc-resolver/binding-android-arm64": "11.7.1", "@oxc-resolver/binding-darwin-arm64": "11.7.1", "@oxc-resolver/binding-darwin-x64": "11.7.1", "@oxc-resolver/binding-freebsd-x64": "11.7.1", "@oxc-resolver/binding-linux-arm-gnueabihf": "11.7.1", "@oxc-resolver/binding-linux-arm-musleabihf": "11.7.1", "@oxc-resolver/binding-linux-arm64-gnu": "11.7.1", "@oxc-resolver/binding-linux-arm64-musl": "11.7.1", "@oxc-resolver/binding-linux-ppc64-gnu": "11.7.1", "@oxc-resolver/binding-linux-riscv64-gnu": "11.7.1", "@oxc-resolver/binding-linux-riscv64-musl": "11.7.1", "@oxc-resolver/binding-linux-s390x-gnu": "11.7.1", "@oxc-resolver/binding-linux-x64-gnu": "11.7.1", "@oxc-resolver/binding-linux-x64-musl": "11.7.1", "@oxc-resolver/binding-wasm32-wasi": "11.7.1", "@oxc-resolver/binding-win32-arm64-msvc": "11.7.1", "@oxc-resolver/binding-win32-ia32-msvc": "11.7.1", "@oxc-resolver/binding-win32-x64-msvc": "11.7.1" } }, "sha512-PzbEnD6NKTCFVKkUZtmQcX69ajdfM33RqI5kyb8mH9EdIqEUS00cWSXN0lsgYrtdTMzwo0EKKoH7hnGg6EDraQ=="],
-
-    "oxlint": ["oxlint@1.13.0", "", { "optionalDependencies": { "@oxlint/darwin-arm64": "1.13.0", "@oxlint/darwin-x64": "1.13.0", "@oxlint/linux-arm64-gnu": "1.13.0", "@oxlint/linux-arm64-musl": "1.13.0", "@oxlint/linux-x64-gnu": "1.13.0", "@oxlint/linux-x64-musl": "1.13.0", "@oxlint/win32-arm64": "1.13.0", "@oxlint/win32-x64": "1.13.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.0.4" }, "optionalPeers": ["oxlint-tsgolint"], "bin": { "oxc_language_server": "bin/oxc_language_server", "oxlint": "bin/oxlint" } }, "sha512-wEoHG0WCbxSfpXqrJPbB6q7j16xoiUJD2WHJffpR9CCPB1ZYgOwf/qRSzH9KGW/Uda7oxm/1Ebx4q4hGALJmeQ=="],
 
     "plural-forms": ["plural-forms@0.5.5", "", {}, "sha512-rJw4xp22izsfJOVqta5Hyvep2lR3xPkFUtj7dyQtpf/FbxUiX7PQCajTn2EHDRylizH5N/Uqqodfdu22I0ju+g=="],
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "catalog": {
       "@types/gettext-parser": "8.0.0",
       "gettext-parser": "8.0.0",
-      "oxlint": "1.13.0",
+      "@biomejs/biome": "2.2.2",
       "plural-forms": "0.5.5",
       "tsx": "4.20.5",
       "typescript": "5.9.2",
@@ -28,7 +28,7 @@
     "@types/gettext-parser": "catalog:",
     "gettext-parser": "catalog:",
     "oxc-resolver": "catalog:",
-    "oxlint": "catalog:",
+    "@biomejs/biome": "catalog:",
     "plural-forms": "catalog:",
     "tree-sitter": "catalog:",
     "tree-sitter-javascript": "catalog:",

--- a/packages/extract/bin/cli.ts
+++ b/packages/extract/bin/cli.ts
@@ -1,18 +1,16 @@
 #!/usr/bin/env node
-import fs from 'node:fs';
-import { extractPo } from '../src/index';
+import fs from "node:fs";
+import { extractPo } from "../src/index";
 
-const [, , entry, locale = 'en', out] = process.argv;
+const [, , entry, locale = "en", out] = process.argv;
 if (!entry) {
-  console.error('Usage: translate-extract <entry> [locale] [out]');
-  process.exit(1);
+	console.error("Usage: translate-extract <entry> [locale] [out]");
+	process.exit(1);
 }
 
 const po = extractPo(entry, locale);
 if (out) {
-  fs.writeFileSync(out, po);
+	fs.writeFileSync(out, po);
 } else {
-  process.stdout.write(po);
+	process.stdout.write(po);
 }
-
-

--- a/packages/extract/index.ts
+++ b/packages/extract/index.ts
@@ -1,1 +1,1 @@
-export * from './src/index';
+export * from "./src/index";

--- a/packages/extract/package.json
+++ b/packages/extract/package.json
@@ -1,30 +1,30 @@
 {
-  "name": "@let-value/translate-extract",
-  "version": "1.0.0",
-  "type": "module",
-  "main": "src/index.ts",
-  "bin": {
-    "translate-extract": "bin/cli.ts"
-  },
-  "dependencies": {
-    "gettext-parser": "catalog:",
-    "oxc-resolver": "catalog:",
-    "plural-forms": "catalog:",
-    "tree-sitter": "catalog:",
-    "tree-sitter-javascript": "catalog:",
-    "tree-sitter-typescript": "catalog:"
-  },
-  "devDependencies": {
-    "@types/gettext-parser": "catalog:",
-    "oxlint": "catalog:",
-    "tsx": "catalog:",
-    "typescript": "catalog:"
-  },
-  "scripts": {
-    "build": "echo building extract",
-    "lint": "oxlint .",
-    "format": "oxlint --fix .",
-    "typecheck": "tsc --noEmit",
-    "test": "tsx test.ts"
-  }
+	"name": "@let-value/translate-extract",
+	"version": "1.0.0",
+	"type": "module",
+	"main": "src/index.ts",
+	"bin": {
+		"translate-extract": "bin/cli.ts"
+	},
+	"dependencies": {
+		"gettext-parser": "catalog:",
+		"oxc-resolver": "catalog:",
+		"plural-forms": "catalog:",
+		"tree-sitter": "catalog:",
+		"tree-sitter-javascript": "catalog:",
+		"tree-sitter-typescript": "catalog:"
+	},
+	"devDependencies": {
+		"@types/gettext-parser": "catalog:",
+		"@biomejs/biome": "catalog:",
+		"tsx": "catalog:",
+		"typescript": "catalog:"
+	},
+	"scripts": {
+		"build": "echo building extract",
+		"lint": "biome lint .",
+		"format": "biome format --write .",
+		"typecheck": "tsc --noEmit",
+		"test": "tsx test.ts"
+	}
 }

--- a/packages/extract/src/index.ts
+++ b/packages/extract/src/index.ts
@@ -1,43 +1,42 @@
-import path from 'node:path';
-import { parseFile } from './parse';
-import { resolveImports } from './walk';
-import { collect as collectImpl, buildPo as buildPoImpl } from './po';
-import type { GetTextTranslation } from 'gettext-parser';
-import type { ParseResult } from './parse';
+import path from "node:path";
+import { parseFile } from "./parse";
+import { resolveImports } from "./walk";
+import { collect as collectImpl, buildPo as buildPoImpl } from "./po";
+import type { GetTextTranslation } from "gettext-parser";
+import type { ParseResult } from "./parse";
 
-export { parseFile } from './parse';
-export type { ParseResult } from './parse';
-export { resolveImports } from './walk';
-export { collect, buildPo } from './po';
-export type { Message } from './po';
+export { parseFile } from "./parse";
+export type { ParseResult } from "./parse";
+export { resolveImports } from "./walk";
+export { collect, buildPo } from "./po";
+export type { Message } from "./po";
 
 /** Walk the dependency graph starting from entry and collect raw messages. */
 export function extract(entry: string): GetTextTranslation[] {
-  const queue = [path.resolve(entry)];
-  const visited = new Set<string>();
-  const all: GetTextTranslation[] = [];
+	const queue = [path.resolve(entry)];
+	const visited = new Set<string>();
+	const all: GetTextTranslation[] = [];
 
-  while (queue.length) {
-    const file = queue.shift()!;
-    if (visited.has(file)) continue;
-    visited.add(file);
+	while (queue.length) {
+		const file = queue.shift()!;
+		if (visited.has(file)) continue;
+		visited.add(file);
 
-    const { messages, imports } = parseFile(file);
-    all.push(...messages);
+		const { messages, imports } = parseFile(file);
+		all.push(...messages);
 
-    const resolved = resolveImports(file, imports);
-    for (const next of resolved) {
-      if (!visited.has(next)) queue.push(next);
-    }
-  }
+		const resolved = resolveImports(file, imports);
+		for (const next of resolved) {
+			if (!visited.has(next)) queue.push(next);
+		}
+	}
 
-  return all;
+	return all;
 }
 
 /** Convenience function to collect and build a PO file. */
 export function extractPo(entry: string, locale: string): string {
-  const raw = extract(entry);
-  const messages = collectImpl(raw);
-  return buildPoImpl(locale, messages);
+	const raw = extract(entry);
+	const messages = collectImpl(raw);
+	return buildPoImpl(locale, messages);
 }
-

--- a/packages/extract/src/parse.ts
+++ b/packages/extract/src/parse.ts
@@ -1,25 +1,25 @@
-import fs from 'node:fs';
-import path from 'node:path';
-import Parser from 'tree-sitter';
-import JavaScript from 'tree-sitter-javascript';
-import TS from 'tree-sitter-typescript';
-import { messageQueries } from './queries';
-import type { GetTextTranslation } from 'gettext-parser';
+import fs from "node:fs";
+import path from "node:path";
+import Parser from "tree-sitter";
+import JavaScript from "tree-sitter-javascript";
+import TS from "tree-sitter-typescript";
+import { messageQueries } from "./queries";
+import type { GetTextTranslation } from "gettext-parser";
 
 function cleanComment(node: Parser.SyntaxNode): string {
-  const text = node.text;
-  if (text.startsWith('/*')) {
-    return text
-      .slice(2, -2)
-      .replace(/^\s*\*?\s*/gm, '')
-      .trim();
-  }
-  return text.replace(/^\/\/\s?/, '').trim();
+	const text = node.text;
+	if (text.startsWith("/*")) {
+		return text
+			.slice(2, -2)
+			.replace(/^\s*\*?\s*/gm, "")
+			.trim();
+	}
+	return text.replace(/^\/\/\s?/, "").trim();
 }
 
 export interface ParseResult {
-  messages: GetTextTranslation[];
-  imports: string[];
+	messages: GetTextTranslation[];
+	imports: string[];
 }
 
 /**
@@ -28,57 +28,58 @@ export interface ParseResult {
  * specifiers found in the file.
  */
 export function parseFile(filePath: string): ParseResult {
-  const absPath = path.resolve(filePath);
-  const source = fs.readFileSync(absPath, 'utf8');
+	const absPath = path.resolve(filePath);
+	const source = fs.readFileSync(absPath, "utf8");
 
-  const parser = new Parser();
-  const ext = path.extname(absPath);
-  const language = (ext === '.ts' || ext === '.tsx'
-    ? (TS.typescript as unknown)
-    : (JavaScript as unknown)) as Parser.Language;
-  parser.setLanguage(language);
-  const tree = parser.parse(source);
+	const parser = new Parser();
+	const ext = path.extname(absPath);
+	const language = (
+		ext === ".ts" || ext === ".tsx"
+			? (TS.typescript as unknown)
+			: (JavaScript as unknown)
+	) as Parser.Language;
+	parser.setLanguage(language);
+	const tree = parser.parse(source);
 
-  const messages: GetTextTranslation[] = [];
-  const imports: string[] = [];
+	const messages: GetTextTranslation[] = [];
+	const imports: string[] = [];
 
-  const seen = new Set<number>();
-  for (const spec of messageQueries) {
-    const query = new Parser.Query(language, spec.pattern);
-    for (const match of query.matches(tree.rootNode)) {
-      for (const { node, translation, comment } of spec.extract(match)) {
-        if (seen.has(node.id)) continue;
-        seen.add(node.id);
-        const line = node.startPosition.row + 1;
-        const rel = path.relative(process.cwd(), absPath);
-        const reference = `${rel}:${line}`;
-        const cleaned = comment ? cleanComment(comment) : undefined;
-        const t: GetTextTranslation = {
-          ...translation,
-          comments: {
-            ...(translation.comments ?? {}),
-            reference,
-            ...(cleaned ? { extracted: cleaned } : {}),
-          },
-        };
-        messages.push(t);
-      }
-    }
-  }
+	const seen = new Set<number>();
+	for (const spec of messageQueries) {
+		const query = new Parser.Query(language, spec.pattern);
+		for (const match of query.matches(tree.rootNode)) {
+			for (const { node, translation, comment } of spec.extract(match)) {
+				if (seen.has(node.id)) continue;
+				seen.add(node.id);
+				const line = node.startPosition.row + 1;
+				const rel = path.relative(process.cwd(), absPath);
+				const reference = `${rel}:${line}`;
+				const cleaned = comment ? cleanComment(comment) : undefined;
+				const t: GetTextTranslation = {
+					...translation,
+					comments: {
+						...(translation.comments ?? {}),
+						reference,
+						...(cleaned ? { extracted: cleaned } : {}),
+					},
+				};
+				messages.push(t);
+			}
+		}
+	}
 
-  const importQuery = new Parser.Query(
-    language,
-    `
+	const importQuery = new Parser.Query(
+		language,
+		`
       (import_statement
         source: (string (string_fragment) @import))
     `,
-  );
+	);
 
-  for (const match of importQuery.matches(tree.rootNode)) {
-    const node = match.captures.find(c => c.name === 'import')!.node;
-    imports.push(node.text);
-  }
+	for (const match of importQuery.matches(tree.rootNode)) {
+		const node = match.captures.find((c) => c.name === "import")!.node;
+		imports.push(node.text);
+	}
 
-  return { messages, imports };
+	return { messages, imports };
 }
-

--- a/packages/extract/src/po.ts
+++ b/packages/extract/src/po.ts
@@ -1,52 +1,58 @@
-import * as gettextParser from 'gettext-parser';
-import { getFormula, getNPlurals } from 'plural-forms';
-import type { GetTextTranslation } from 'gettext-parser';
+import * as gettextParser from "gettext-parser";
+import { getFormula, getNPlurals } from "plural-forms";
+import type { GetTextTranslation } from "gettext-parser";
 
 export interface Message {
-  msgid: string;
-  msgstr: string[];
-  references: string[];
-  comments: string[];
+	msgid: string;
+	msgstr: string[];
+	references: string[];
+	comments: string[];
 }
 
 /** Combine raw messages into unique translation messages. */
 export function collect(raw: GetTextTranslation[]): Message[] {
-  const map = new Map<string, Message>();
-  for (const m of raw) {
-    if (!map.has(m.msgid)) {
-      map.set(m.msgid, { msgid: m.msgid, msgstr: [], references: [], comments: [] });
-    }
-    const entry = map.get(m.msgid)!;
-    if (entry.msgstr.length === 0 && m.msgstr.length) entry.msgstr = m.msgstr;
-    if (m.comments?.reference) entry.references.push(m.comments.reference);
-    if (m.comments?.extracted) entry.comments.push(m.comments.extracted);
-  }
-  return Array.from(map.values());
+	const map = new Map<string, Message>();
+	for (const m of raw) {
+		if (!map.has(m.msgid)) {
+			map.set(m.msgid, {
+				msgid: m.msgid,
+				msgstr: [],
+				references: [],
+				comments: [],
+			});
+		}
+		const entry = map.get(m.msgid)!;
+		if (entry.msgstr.length === 0 && m.msgstr.length) entry.msgstr = m.msgstr;
+		if (m.comments?.reference) entry.references.push(m.comments.reference);
+		if (m.comments?.extracted) entry.comments.push(m.comments.extracted);
+	}
+	return Array.from(map.values());
 }
 
 /** Build a PO file string from messages and locale. */
 export function buildPo(locale: string, messages: Message[]): string {
-  const headers = {
-    'content-type': 'text/plain; charset=UTF-8',
-    'plural-forms': `nplurals=${getNPlurals(locale)}; plural=${getFormula(locale)};`,
-    language: locale
-  } as Record<string, string>;
+	const headers = {
+		"content-type": "text/plain; charset=UTF-8",
+		"plural-forms": `nplurals=${getNPlurals(locale)}; plural=${getFormula(locale)};`,
+		language: locale,
+	} as Record<string, string>;
 
-  const poObj: any = {
-    charset: 'utf-8',
-    headers,
-    translations: { '': {} as Record<string, any> }
-  };
+	const poObj: any = {
+		charset: "utf-8",
+		headers,
+		translations: { "": {} as Record<string, any> },
+	};
 
-  for (const m of messages) {
-    poObj.translations[''][m.msgid] = {
-      msgid: m.msgid,
-      msgstr: m.msgstr.length ? m.msgstr : [''],
-      references: m.references.join('\n'),
-      comments: m.comments.length ? { extracted: m.comments.join('\n') } : undefined
-    };
-  }
+	for (const m of messages) {
+		poObj.translations[""][m.msgid] = {
+			msgid: m.msgid,
+			msgstr: m.msgstr.length ? m.msgstr : [""],
+			references: m.references.join("\n"),
+			comments: m.comments.length
+				? { extracted: m.comments.join("\n") }
+				: undefined,
+		};
+	}
 
-  return gettextParser.po.compile(poObj).toString();
+	return gettextParser.po.compile(poObj).toString();
 }
-

--- a/packages/extract/src/queries/index.ts
+++ b/packages/extract/src/queries/index.ts
@@ -1,13 +1,18 @@
-import { tQuery } from './t';
-import { msgStringQuery, msgStringPairQuery, msgDescriptorQuery, msgTemplateQuery } from './msg';
-import type { QuerySpec } from './types';
+import { tQuery } from "./t";
+import {
+	msgStringQuery,
+	msgStringPairQuery,
+	msgDescriptorQuery,
+	msgTemplateQuery,
+} from "./msg";
+import type { QuerySpec } from "./types";
 
-export type { QuerySpec, MessageMatch } from './types';
+export type { QuerySpec, MessageMatch } from "./types";
 
 export const messageQueries: QuerySpec[] = [
-  msgStringPairQuery,
-  msgStringQuery,
-  msgDescriptorQuery,
-  msgTemplateQuery,
-  tQuery,
+	msgStringPairQuery,
+	msgStringQuery,
+	msgDescriptorQuery,
+	msgTemplateQuery,
+	tQuery,
 ];

--- a/packages/extract/src/queries/msg.ts
+++ b/packages/extract/src/queries/msg.ts
@@ -1,5 +1,5 @@
-import type { QuerySpec } from './types';
-import { withLeadingComment } from './helpers';
+import type { QuerySpec } from "./types";
+import { withLeadingComment } from "./helpers";
 
 const msgCall = (args: string) => `(
   (call_expression
@@ -10,33 +10,41 @@ const msgCall = (args: string) => `(
 )`;
 
 export const msgStringQuery: QuerySpec = {
-  pattern: withLeadingComment(msgCall(`(arguments
+	pattern: withLeadingComment(
+		msgCall(`(arguments
     (string (string_fragment) @msgid)
-  )`)),
-  extract(match) {
-    const call = match.captures.find(c => c.name === 'call')!.node;
-    const msgid = match.captures.find(c => c.name === 'msgid')!.node.text;
-    const comment = match.captures.find(c => c.name === 'comment')?.node;
-    return [{ node: call, translation: { msgid, msgstr: [] }, comment }];
-  },
+  )`),
+	),
+	extract(match) {
+		const call = match.captures.find((c) => c.name === "call")!.node;
+		const msgid = match.captures.find((c) => c.name === "msgid")!.node.text;
+		const comment = match.captures.find((c) => c.name === "comment")?.node;
+		return [{ node: call, translation: { msgid, msgstr: [] }, comment }];
+	},
 };
 
 export const msgStringPairQuery: QuerySpec = {
-  pattern: withLeadingComment(msgCall(`(arguments
+	pattern: withLeadingComment(
+		msgCall(`(arguments
     (string (string_fragment) @msgid)
     (string (string_fragment) @msgstr)
-  )`)),
-  extract(match) {
-    const call = match.captures.find(c => c.name === 'call')!.node;
-    const msgid = match.captures.find(c => c.name === 'msgid')!.node.text;
-    const msgstrNode = match.captures.find(c => c.name === 'msgstr')!.node.text;
-    const comment = match.captures.find(c => c.name === 'comment')?.node;
-    return [{ node: call, translation: { msgid, msgstr: [msgstrNode] }, comment }];
-  },
+  )`),
+	),
+	extract(match) {
+		const call = match.captures.find((c) => c.name === "call")!.node;
+		const msgid = match.captures.find((c) => c.name === "msgid")!.node.text;
+		const msgstrNode = match.captures.find((c) => c.name === "msgstr")!.node
+			.text;
+		const comment = match.captures.find((c) => c.name === "comment")?.node;
+		return [
+			{ node: call, translation: { msgid, msgstr: [msgstrNode] }, comment },
+		];
+	},
 };
 
 export const msgDescriptorQuery: QuerySpec = {
-  pattern: withLeadingComment(msgCall(`(arguments
+	pattern: withLeadingComment(
+		msgCall(`(arguments
     (object
       (_)*
       (pair
@@ -52,26 +60,27 @@ export const msgDescriptorQuery: QuerySpec = {
       )?
       (_)*
     )
-  )`)),
-  extract(match) {
-    const call = match.captures.find(c => c.name === 'call')!.node;
-    const id = match.captures.find(c => c.name === 'id')?.node.text;
-    const message = match.captures.find(c => c.name === 'message')?.node.text;
-    const msgid = id ?? message;
-    if (!msgid) return [];
-    const msgstr = id && message ? [message] : [];
-    const comment = match.captures.find(c => c.name === 'comment')?.node;
-    return [{ node: call, translation: { msgid, msgstr }, comment }];
-  },
+  )`),
+	),
+	extract(match) {
+		const call = match.captures.find((c) => c.name === "call")!.node;
+		const id = match.captures.find((c) => c.name === "id")?.node.text;
+		const message = match.captures.find((c) => c.name === "message")?.node.text;
+		const msgid = id ?? message;
+		if (!msgid) return [];
+		const msgstr = id && message ? [message] : [];
+		const comment = match.captures.find((c) => c.name === "comment")?.node;
+		return [{ node: call, translation: { msgid, msgstr }, comment }];
+	},
 };
 
 export const msgTemplateQuery: QuerySpec = {
-  pattern: withLeadingComment(msgCall(`(template_string) @tpl`)),
-  extract(match) {
-    const call = match.captures.find(c => c.name === 'call')!.node;
-    const tpl = match.captures.find(c => c.name === 'tpl')!.node;
-    const text = tpl.text.slice(1, -1);
-    const comment = match.captures.find(c => c.name === 'comment')?.node;
-    return [{ node: call, translation: { msgid: text, msgstr: [] }, comment }];
-  },
+	pattern: withLeadingComment(msgCall(`(template_string) @tpl`)),
+	extract(match) {
+		const call = match.captures.find((c) => c.name === "call")!.node;
+		const tpl = match.captures.find((c) => c.name === "tpl")!.node;
+		const text = tpl.text.slice(1, -1);
+		const comment = match.captures.find((c) => c.name === "comment")?.node;
+		return [{ node: call, translation: { msgid: text, msgstr: [] }, comment }];
+	},
 };

--- a/packages/extract/src/queries/t.ts
+++ b/packages/extract/src/queries/t.ts
@@ -1,5 +1,5 @@
-import type { QuerySpec } from './types';
-import { withLeadingComment } from './helpers';
+import type { QuerySpec } from "./types";
+import { withLeadingComment } from "./helpers";
 
 const callPattern = `(
   (call_expression
@@ -10,11 +10,17 @@ const callPattern = `(
 )`;
 
 export const tQuery: QuerySpec = {
-  pattern: withLeadingComment(callPattern),
-  extract(match) {
-    const call = match.captures.find(c => c.name === 'call')!.node;
-    const msgidNode = match.captures.find(c => c.name === 'msgid')!.node;
-    const comment = match.captures.find(c => c.name === 'comment')?.node;
-    return [{ node: call, translation: { msgid: msgidNode.text, msgstr: [] }, comment }];
-  }
+	pattern: withLeadingComment(callPattern),
+	extract(match) {
+		const call = match.captures.find((c) => c.name === "call")!.node;
+		const msgidNode = match.captures.find((c) => c.name === "msgid")!.node;
+		const comment = match.captures.find((c) => c.name === "comment")?.node;
+		return [
+			{
+				node: call,
+				translation: { msgid: msgidNode.text, msgstr: [] },
+				comment,
+			},
+		];
+	},
 };

--- a/packages/extract/src/queries/types.ts
+++ b/packages/extract/src/queries/types.ts
@@ -1,13 +1,13 @@
-import type Parser from 'tree-sitter';
-import type { GetTextTranslation } from 'gettext-parser';
+import type Parser from "tree-sitter";
+import type { GetTextTranslation } from "gettext-parser";
 
 export interface MessageMatch {
-  node: Parser.SyntaxNode;
-  translation: GetTextTranslation;
-  comment?: Parser.SyntaxNode;
+	node: Parser.SyntaxNode;
+	translation: GetTextTranslation;
+	comment?: Parser.SyntaxNode;
 }
 
 export interface QuerySpec {
-  pattern: string;
-  extract(match: Parser.QueryMatch): MessageMatch[];
+	pattern: string;
+	extract(match: Parser.QueryMatch): MessageMatch[];
 }

--- a/packages/extract/src/walk.ts
+++ b/packages/extract/src/walk.ts
@@ -1,5 +1,5 @@
-import path from 'node:path';
-import resolver from 'oxc-resolver';
+import path from "node:path";
+import resolver from "oxc-resolver";
 
 /**
  * Resolve a list of import specifiers relative to a file.
@@ -9,14 +9,13 @@ import resolver from 'oxc-resolver';
  * @returns Absolute paths to resolved modules.
  */
 export function resolveImports(file: string, imports: string[]): string[] {
-  const dir = path.dirname(path.resolve(file));
-  const resolved: string[] = [];
-  for (const spec of imports) {
-    const res = resolver.sync(dir, spec) as { path?: string };
-    if (res.path) {
-      resolved.push(res.path);
-    }
-  }
-  return resolved;
+	const dir = path.dirname(path.resolve(file));
+	const resolved: string[] = [];
+	for (const spec of imports) {
+		const res = resolver.sync(dir, spec) as { path?: string };
+		if (res.path) {
+			resolved.push(res.path);
+		}
+	}
+	return resolved;
 }
-

--- a/packages/extract/test.ts
+++ b/packages/extract/test.ts
@@ -1,69 +1,72 @@
-import assert from 'node:assert';
-import fs from 'node:fs';
-import os from 'node:os';
-import path from 'node:path';
-import { execSync } from 'node:child_process';
-import { createRequire } from 'node:module';
-import { fileURLToPath } from 'node:url';
+import assert from "node:assert";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execSync } from "node:child_process";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
 
-import { parseFile } from './src/parse';
-import { resolveImports } from './src/walk';
-import { collect, buildPo } from './src/po';
-import { extract, extractPo } from './src';
+import { parseFile } from "./src/parse";
+import { resolveImports } from "./src/walk";
+import { collect, buildPo } from "./src/po";
+import { extract, extractPo } from "./src";
 
 const require = createRequire(import.meta.url);
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'translate-extract-'));
-fs.writeFileSync(path.join(tmp, 'dep.js'), "// World comment\n t('World');\n");
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "translate-extract-"));
+fs.writeFileSync(path.join(tmp, "dep.js"), "// World comment\n t('World');\n");
 fs.writeFileSync(
-  path.join(tmp, 'entry.js'),
-  "import './dep.js';\n // Greeting\n t('Hello');\n",
+	path.join(tmp, "entry.js"),
+	"import './dep.js';\n // Greeting\n t('Hello');\n",
 );
 
-const entry = path.join(tmp, 'entry.js');
+const entry = path.join(tmp, "entry.js");
 
 // parseFile should read only current file
 const parsed = parseFile(entry);
-assert.deepStrictEqual(parsed.messages.map(m => m.msgid), ['Hello']);
-assert.strictEqual(parsed.messages[0]?.comments?.extracted, 'Greeting');
-assert.deepStrictEqual(parsed.imports, ['./dep.js']);
+assert.deepStrictEqual(
+	parsed.messages.map((m) => m.msgid),
+	["Hello"],
+);
+assert.strictEqual(parsed.messages[0]?.comments?.extracted, "Greeting");
+assert.deepStrictEqual(parsed.imports, ["./dep.js"]);
 
 // resolveImports should resolve import paths
 const resolved = resolveImports(entry, parsed.imports);
-assert.deepStrictEqual(resolved, [path.join(tmp, 'dep.js')]);
+assert.deepStrictEqual(resolved, [path.join(tmp, "dep.js")]);
 
 // extract should walk dependency graph
 const walked = extract(entry);
 const messages = collect(walked);
-assert(messages.some(m => m.msgid === 'Hello'));
-assert(messages.some(m => m.msgid === 'World'));
-const worldMsg = messages.find(m => m.msgid === 'World');
-assert(worldMsg?.comments.includes('World comment'));
+assert(messages.some((m) => m.msgid === "Hello"));
+assert(messages.some((m) => m.msgid === "World"));
+const worldMsg = messages.find((m) => m.msgid === "World");
+assert(worldMsg?.comments.includes("World comment"));
 
 // buildPo should include all messages
-const po = buildPo('en', messages);
-assert(po.includes('Hello') && po.includes('World'));
+const po = buildPo("en", messages);
+assert(po.includes("Hello") && po.includes("World"));
 
 // convenience extractPo should work
-const po2 = extractPo(entry, 'en');
-assert(po2.includes('Hello') && po2.includes('World'));
+const po2 = extractPo(entry, "en");
+assert(po2.includes("Hello") && po2.includes("World"));
 
 // CLI should output the same
-const cli = path.resolve(__dirname, 'bin/cli.ts');
-const tsx = require.resolve('tsx/cli');
+const cli = path.resolve(__dirname, "bin/cli.ts");
+const tsx = require.resolve("tsx/cli");
 const output = execSync(`node ${tsx} ${cli} entry.js en`, {
-  cwd: tmp,
-  encoding: 'utf8'
+	cwd: tmp,
+	encoding: "utf8",
 });
-assert(output.includes('Hello'));
-assert(output.includes('World'));
+assert(output.includes("Hello"));
+assert(output.includes("World"));
 
 // msg query should extract various message forms
-const tmpMsg = fs.mkdtempSync(path.join(os.tmpdir(), 'translate-msg-'));
+const tmpMsg = fs.mkdtempSync(path.join(os.tmpdir(), "translate-msg-"));
 fs.writeFileSync(
-  path.join(tmpMsg, 'entry.js'),
-  `
+	path.join(tmpMsg, "entry.js"),
+	`
 msg('hello', 'hola');
 msg({ id: 'greeting', message: 'Hello world' });
 msg({ id: 'onlyId' });
@@ -75,16 +78,23 @@ msg\`Hello, \${name}!\`;
 `,
 );
 
-const parsedMsg = parseFile(path.join(tmpMsg, 'entry.js'));
+const parsedMsg = parseFile(path.join(tmpMsg, "entry.js"));
 assert.deepStrictEqual(
-  parsedMsg.messages.map(m => m.msgid).sort(),
-  ['hello', 'greeting', 'onlyId', 'onlyMessage', 'Hello!', 'Hello, ${name}!'].sort(),
+	parsedMsg.messages.map((m) => m.msgid).sort(),
+	[
+		"hello",
+		"greeting",
+		"onlyId",
+		"onlyMessage",
+		"Hello!",
+		"Hello, ${name}!",
+	].sort(),
 );
-const hello = parsedMsg.messages.find(m => m.msgid === 'hello');
-assert.deepStrictEqual(hello?.msgstr, ['hola']);
-const greeting = parsedMsg.messages.find(m => m.msgid === 'greeting');
-assert.deepStrictEqual(greeting?.msgstr, ['Hello world']);
-const commentMsg = parsedMsg.messages.find(m => m.msgid === 'Hello!');
-assert.strictEqual(commentMsg?.comments?.extracted, 'some');
+const hello = parsedMsg.messages.find((m) => m.msgid === "hello");
+assert.deepStrictEqual(hello?.msgstr, ["hola"]);
+const greeting = parsedMsg.messages.find((m) => m.msgid === "greeting");
+assert.deepStrictEqual(greeting?.msgstr, ["Hello world"]);
+const commentMsg = parsedMsg.messages.find((m) => m.msgid === "Hello!");
+assert.strictEqual(commentMsg?.comments?.extracted, "some");
 
-console.log('extract tests passed');
+console.log("extract tests passed");

--- a/packages/extract/tsconfig.json
+++ b/packages/extract/tsconfig.json
@@ -1,3 +1,3 @@
 {
-  "extends": "../../tsconfig.json",
+	"extends": "../../tsconfig.json"
 }

--- a/packages/translate/index.ts
+++ b/packages/translate/index.ts
@@ -1,1 +1,1 @@
-export * from './src/index';
+export * from "./src/index";

--- a/packages/translate/package.json
+++ b/packages/translate/package.json
@@ -1,26 +1,26 @@
 {
-  "name": "@let-value/translate",
-  "version": "1.0.0",
-  "type": "module",
-  "main": "src/index.ts",
-  "exports": {
-    ".": "./src/index.ts"
-  },
-  "scripts": {
-    "build": "echo building translate",
-    "lint": "oxlint .",
-    "format": "oxlint --fix .",
-    "typecheck": "tsc --noEmit",
-    "test": "tsx --test test/*.test.ts"
-  },
-  "dependencies": {
-    "plural-forms": "catalog:"
-  },
-  "devDependencies": {
-    "@types/gettext-parser": "catalog:",
-    "gettext-parser": "catalog:",
-    "oxlint": "catalog:",
-    "tsx": "catalog:",
-    "typescript": "catalog:"
-  }
+	"name": "@let-value/translate",
+	"version": "1.0.0",
+	"type": "module",
+	"main": "src/index.ts",
+	"exports": {
+		".": "./src/index.ts"
+	},
+	"scripts": {
+		"build": "echo building translate",
+		"lint": "biome lint .",
+		"format": "biome format --write .",
+		"typecheck": "tsc --noEmit",
+		"test": "tsx --test test/*.test.ts"
+	},
+	"dependencies": {
+		"plural-forms": "catalog:"
+	},
+	"devDependencies": {
+		"@types/gettext-parser": "catalog:",
+		"gettext-parser": "catalog:",
+		"@biomejs/biome": "catalog:",
+		"tsx": "catalog:",
+		"typescript": "catalog:"
+	}
 }

--- a/packages/translate/src/helpers.ts
+++ b/packages/translate/src/helpers.ts
@@ -1,90 +1,96 @@
 import { assert, StrictStaticString } from "./utils";
 
 export interface MessageDescriptor {
-  id?: string;
-  message?: string;
+	id?: string;
+	message?: string;
 }
 
 export interface MessageId {
-  msgid: string;
-  msgstr: string;
-  values?: any[];
+	msgid: string;
+	msgstr: string;
+	values?: any[];
 }
 
 export interface PluralMessageId {
-  forms: MessageId[];
-  n: number;
+	forms: MessageId[];
+	n: number;
 }
 
 export interface ContextMessageId {
-  context: string;
-  id: MessageId;
+	context: string;
+	id: MessageId;
 }
 
 export interface ContextPluralMessageId {
-  context: string;
-  id: PluralMessageId;
+	context: string;
+	id: PluralMessageId;
 }
 
 function buildFromTemplate(strings: TemplateStringsArray): string {
-  let result = '';
-  for (let i = 0; i < strings.length; i++) {
-    result += strings[i];
-    if (i < strings.length - 1) result += '${' + i + '}';
-  }
-  return result;
+	let result = "";
+	for (let i = 0; i < strings.length; i++) {
+		result += strings[i];
+		if (i < strings.length - 1) result += "${" + i + "}";
+	}
+	return result;
 }
 
 export function msg<T extends string>(id: StrictStaticString<T>): MessageId;
 export function msg(descriptor: MessageDescriptor): MessageId;
-export function msg(strings: TemplateStringsArray, ...values: unknown[]): MessageId;
-export function msg(source: string | MessageDescriptor | TemplateStringsArray, ...values: unknown[]): MessageId {
-  if (typeof source === 'string') {
-    return { msgid: source, msgstr: source };
-  }
+export function msg(
+	strings: TemplateStringsArray,
+	...values: unknown[]
+): MessageId;
+export function msg(
+	source: string | MessageDescriptor | TemplateStringsArray,
+	...values: unknown[]
+): MessageId {
+	if (typeof source === "string") {
+		return { msgid: source, msgstr: source };
+	}
 
-  if (typeof source === 'object' && "reduce" in source) {
-    const id = buildFromTemplate(source);
-    return { msgid: id, msgstr: id, values };
-  }
+	if (typeof source === "object" && "reduce" in source) {
+		const id = buildFromTemplate(source);
+		return { msgid: id, msgstr: id, values };
+	}
 
-  const id = source.id ?? source.message ?? '';
-  const message = source.message ?? source.id ?? '';
-  return { msgid: id, msgstr: message };
+	const id = source.id ?? source.message ?? "";
+	const message = source.message ?? source.id ?? "";
+	return { msgid: id, msgstr: message };
 }
 
 export type MessageFunction = typeof msg;
 
 export function plural(
-  ...args: [...forms: MessageId[], n: number]
+	...args: [...forms: MessageId[], n: number]
 ): PluralMessageId {
-  assert(args.length > 1, 'At least one plural form and n are required');
+	assert(args.length > 1, "At least one plural form and n are required");
 
-  const n = args[args.length - 1] as number;
-  assert(typeof n === 'number', 'The last argument must be a number');
+	const n = args[args.length - 1] as number;
+	assert(typeof n === "number", "The last argument must be a number");
 
-  const forms = args.slice(0, -1) as MessageId[];
+	const forms = args.slice(0, -1) as MessageId[];
 
-  return { forms, n };
+	return { forms, n };
 }
 
 export type PluralFunction = typeof plural;
 
 export interface ContextBuilder {
-  msg<T extends string>(id: StrictStaticString<T>): ContextMessageId;
-  msg(...args: Parameters<MessageFunction>): ContextMessageId;
-  plural(...args: Parameters<PluralFunction>): ContextPluralMessageId;
+	msg<T extends string>(id: StrictStaticString<T>): ContextMessageId;
+	msg(...args: Parameters<MessageFunction>): ContextMessageId;
+	plural(...args: Parameters<PluralFunction>): ContextPluralMessageId;
 }
 
 const basePlural = plural;
 
 export function context(context: string): ContextBuilder {
-  return {
-    msg: (...args: Parameters<MessageFunction>) => {
-      return { id: msg(...args), context };
-    },
-    plural(...forms: Parameters<PluralFunction>) {
-      return { id: basePlural(...forms), context };
-    },
-  };
+	return {
+		msg: (...args: Parameters<MessageFunction>) => {
+			return { id: msg(...args), context };
+		},
+		plural(...forms: Parameters<PluralFunction>) {
+			return { id: basePlural(...forms), context };
+		},
+	};
 }

--- a/packages/translate/src/index.ts
+++ b/packages/translate/src/index.ts
@@ -1,2 +1,2 @@
-export * from './helpers.ts';
-export * from './translator.ts';
+export * from "./helpers.ts";
+export * from "./translator.ts";

--- a/packages/translate/src/plural-forms.d.ts
+++ b/packages/translate/src/plural-forms.d.ts
@@ -1,9 +1,13 @@
-declare module 'plural-forms' {
-    export declare function getFormula(language: string): string;
-    export declare function getNPlurals(language: string): number;
-    export declare function getPluralFunc(language: string): (plural: number, wordForms: string[]) => string | undefined;
-    export declare function hasLang(language: string): boolean;
-    export declare function getPluralFormsHeader(language: string): string;
-    export declare function getAvailLangs(): string[];
-    export declare function getExamples(language: string): Array<{ plural: number, sample: number }>;
+declare module "plural-forms" {
+	export declare function getFormula(language: string): string;
+	export declare function getNPlurals(language: string): number;
+	export declare function getPluralFunc(
+		language: string,
+	): (plural: number, wordForms: string[]) => string | undefined;
+	export declare function hasLang(language: string): boolean;
+	export declare function getPluralFormsHeader(language: string): string;
+	export declare function getAvailLangs(): string[];
+	export declare function getExamples(
+		language: string,
+	): Array<{ plural: number; sample: number }>;
 }

--- a/packages/translate/src/translator.ts
+++ b/packages/translate/src/translator.ts
@@ -1,106 +1,122 @@
-import type { GetTextTranslations } from 'gettext-parser';
+import type { GetTextTranslations } from "gettext-parser";
 import {
-  msg,
-  MessageId,
-  PluralMessageId,
-  ContextMessageId,
-  ContextPluralMessageId,
-  plural,
-  MessageFunction,
-  PluralFunction,
-  MessageDescriptor,
-} from './helpers.ts';
-import { pluralFunc, StrictStaticString, substitute } from './utils.ts';
+	msg,
+	MessageId,
+	PluralMessageId,
+	ContextMessageId,
+	ContextPluralMessageId,
+	plural,
+	MessageFunction,
+	PluralFunction,
+	MessageDescriptor,
+} from "./helpers.ts";
+import { pluralFunc, StrictStaticString, substitute } from "./utils.ts";
 
 export class Translator {
-  private locale: string;
-  private translations: Record<string, GetTextTranslations> = {};
+	private locale: string;
+	private translations: Record<string, GetTextTranslations> = {};
 
-  constructor(
-    defaultLocale: string,
-    translations: Record<string, GetTextTranslations>
-  ) {
-    this.locale = defaultLocale;
-    this.translations = translations;
-  }
+	constructor(
+		defaultLocale: string,
+		translations: Record<string, GetTextTranslations>,
+	) {
+		this.locale = defaultLocale;
+		this.translations = translations;
+	}
 
-  msg = msg;
-  plural = plural;
+	msg = msg;
+	plural = plural;
 
-  useLocale(locale: string): void {
-    this.locale = locale;
-  }
+	useLocale(locale: string): void {
+		this.locale = locale;
+	}
 
-  getText({ msgid, msgstr, values }: MessageId, msgctxt = ''): string {
-    const translated = this.translations[this.locale]?.translations?.[msgctxt]?.[msgid];
-    const result = translated && translated.msgstr ? translated.msgstr[0] : msgstr;
-    return values ? substitute(result, values) : result;
-  }
+	getText({ msgid, msgstr, values }: MessageId, msgctxt = ""): string {
+		const translated =
+			this.translations[this.locale]?.translations?.[msgctxt]?.[msgid];
+		const result =
+			translated && translated.msgstr ? translated.msgstr[0] : msgstr;
+		return values ? substitute(result, values) : result;
+	}
 
-  getPluralText({ forms, n }: PluralMessageId, msgctxt = ''): string {
-    const entry = this.translations[this.locale]?.translations?.[msgctxt]?.[forms[0].msgid];
-    const index = pluralFunc(this.locale)(n);
-    const form = forms[index] ?? forms[forms.length - 1];
-    const translated = entry?.msgstr?.[index];
-    const result = translated && translated.length ? translated : form.msgstr;
-    const usedVals = form.values && form.values.length ? form.values : forms[0].values;
-    return usedVals && usedVals.length ? substitute(result, usedVals) : result;
-  }
+	getPluralText({ forms, n }: PluralMessageId, msgctxt = ""): string {
+		const entry =
+			this.translations[this.locale]?.translations?.[msgctxt]?.[forms[0].msgid];
+		const index = pluralFunc(this.locale)(n);
+		const form = forms[index] ?? forms[forms.length - 1];
+		const translated = entry?.msgstr?.[index];
+		const result = translated && translated.length ? translated : form.msgstr;
+		const usedVals =
+			form.values && form.values.length ? form.values : forms[0].values;
+		return usedVals && usedVals.length ? substitute(result, usedVals) : result;
+	}
 
-  gettext(id: MessageId): string;
-  gettext<T extends string>(id: StrictStaticString<T>): string;
-  gettext(...args: Parameters<MessageFunction>): string;
-  gettext(...args: [MessageId] | Parameters<MessageFunction>): string {
-    const [source] = args;
+	gettext(id: MessageId): string;
+	gettext<T extends string>(id: StrictStaticString<T>): string;
+	gettext(...args: Parameters<MessageFunction>): string;
+	gettext(...args: [MessageId] | Parameters<MessageFunction>): string {
+		const [source] = args;
 
-    if (typeof source === 'object' && 'msgid' in source) {
-      return this.getText(source);
-    }
+		if (typeof source === "object" && "msgid" in source) {
+			return this.getText(source);
+		}
 
-    return this.getText(msg(...args as Parameters<MessageFunction>));
-  }
+		return this.getText(msg(...(args as Parameters<MessageFunction>)));
+	}
 
-  pgettext(id: ContextMessageId): string;
-  pgettext<T extends string>(context: string, id: StrictStaticString<T>): string;
-  pgettext(context: string, descriptor: MessageDescriptor): string;
-  pgettext(context: string, id: MessageId): string;
-  pgettext(context: ContextMessageId | string, second?: string | MessageDescriptor | MessageId): string {
-    if (typeof context === "object") {
-      return this.getText(context.id, context.context);
-    }
+	pgettext(id: ContextMessageId): string;
+	pgettext<T extends string>(
+		context: string,
+		id: StrictStaticString<T>,
+	): string;
+	pgettext(context: string, descriptor: MessageDescriptor): string;
+	pgettext(context: string, id: MessageId): string;
+	pgettext(
+		context: ContextMessageId | string,
+		second?: string | MessageDescriptor | MessageId,
+	): string {
+		if (typeof context === "object") {
+			return this.getText(context.id, context.context);
+		}
 
-    if (typeof second === 'object' && 'msgid' in second) {
-      return this.getText(second, context);
-    }
+		if (typeof second === "object" && "msgid" in second) {
+			return this.getText(second, context);
+		}
 
-    return this.getText(msg(second as MessageDescriptor), context);
-  }
+		return this.getText(msg(second as MessageDescriptor), context);
+	}
 
-  ngettext(id: PluralMessageId): string;
-  ngettext(...args: Parameters<PluralFunction>): string;
-  ngettext(...args: [PluralMessageId] | Parameters<PluralFunction>): string {
-    const [source] = args;
+	ngettext(id: PluralMessageId): string;
+	ngettext(...args: Parameters<PluralFunction>): string;
+	ngettext(...args: [PluralMessageId] | Parameters<PluralFunction>): string {
+		const [source] = args;
 
-    if (typeof source === 'object' && 'forms' in source) {
-      return this.getPluralText(source);
-    }
+		if (typeof source === "object" && "forms" in source) {
+			return this.getPluralText(source);
+		}
 
-    return this.getPluralText(plural(...args as Parameters<PluralFunction>));
-  }
+		return this.getPluralText(plural(...(args as Parameters<PluralFunction>)));
+	}
 
-  npgettext(id: ContextPluralMessageId): string;
-  npgettext(context: string, ...args: Parameters<typeof this.ngettext>): string;
-  npgettext(context: ContextPluralMessageId | string, ...args: [] | [PluralMessageId] | Parameters<PluralFunction>): string {
-    if (typeof context === "object") {
-      return this.getPluralText(context.id, context.context);
-    }
+	npgettext(id: ContextPluralMessageId): string;
+	npgettext(context: string, ...args: Parameters<typeof this.ngettext>): string;
+	npgettext(
+		context: ContextPluralMessageId | string,
+		...args: [] | [PluralMessageId] | Parameters<PluralFunction>
+	): string {
+		if (typeof context === "object") {
+			return this.getPluralText(context.id, context.context);
+		}
 
-    const [source] = args;
+		const [source] = args;
 
-    if (typeof source === 'object' && 'forms' in source) {
-      return this.getPluralText(source, context);
-    }
+		if (typeof source === "object" && "forms" in source) {
+			return this.getPluralText(source, context);
+		}
 
-    return this.getPluralText(plural(...args as Parameters<PluralFunction>), context);
-  }
+		return this.getPluralText(
+			plural(...(args as Parameters<PluralFunction>)),
+			context,
+		);
+	}
 }

--- a/packages/translate/src/utils.ts
+++ b/packages/translate/src/utils.ts
@@ -1,49 +1,54 @@
 import { getNPlurals, getPluralFunc } from "plural-forms";
 
-export type IsUnion<T, U = T> =
-    (T extends any ? (x: T) => 0 : never) extends (x: U) => 0 ? false : true;
+export type IsUnion<T, U = T> = (T extends any ? (x: T) => 0 : never) extends (
+	x: U,
+) => 0
+	? false
+	: true;
 
-export type StrictStaticString<T extends string> =
-    string extends T ? never : IsUnion<T> extends true ? never : T;
+export type StrictStaticString<T extends string> = string extends T
+	? never
+	: IsUnion<T> extends true
+		? never
+		: T;
 
 export function assert<T>(value: T, message?: string): asserts value is T {
-    if (!value) {
-        throw new Error(message || 'Assertion failed');
-    }
+	if (!value) {
+		throw new Error(message || "Assertion failed");
+	}
 }
 
 export function memo<T extends (...args: any[]) => any>(fn: T): T {
-    const cache = new Map<string, ReturnType<T>>();
-    return function (...args: Parameters<T>): ReturnType<T> {
-        const key = JSON.stringify(args);
-        if (cache.has(key)) {
-            return cache.get(key)!;
-        }
-        const result = fn(...args);
-        cache.set(key, result);
-        return result;
-    } as T;
+	const cache = new Map<string, ReturnType<T>>();
+	return function (...args: Parameters<T>): ReturnType<T> {
+		const key = JSON.stringify(args);
+		if (cache.has(key)) {
+			return cache.get(key)!;
+		}
+		const result = fn(...args);
+		cache.set(key, result);
+		return result;
+	} as T;
 }
 
 export function substitute(text: string, values: any[] = []): string {
-    return text
-        .replace(/\$\{(\d+)\}/g, (_, i) => String(values[Number(i)]));
+	return text.replace(/\$\{(\d+)\}/g, (_, i) => String(values[Number(i)]));
 }
 
 const defaultPluralFunc = (n: number) => (n !== 1 ? 1 : 0);
 
 export const pluralFunc = memo(function pluralFunc(locale: string) {
-    try {
-        const length = Number(getNPlurals(locale));
-        const pluralFunc = getPluralFunc(locale);
-        const forms = Array.from({ length }, (_, i) => String(i));
-        return (n: number) => {
-            const idx = Number(pluralFunc(n, forms));
-            if (idx < 0) return 0;
-            if (idx >= length) return length - 1;
-            return idx;
-        };
-    } catch {
-        return defaultPluralFunc;
-    }
-})
+	try {
+		const length = Number(getNPlurals(locale));
+		const pluralFunc = getPluralFunc(locale);
+		const forms = Array.from({ length }, (_, i) => String(i));
+		return (n: number) => {
+			const idx = Number(pluralFunc(n, forms));
+			if (idx < 0) return 0;
+			if (idx >= length) return length - 1;
+			return idx;
+		};
+	} catch {
+		return defaultPluralFunc;
+	}
+});

--- a/packages/translate/test/context.test.ts
+++ b/packages/translate/test/context.test.ts
@@ -1,16 +1,19 @@
-import { test } from 'node:test';
-import assert from 'node:assert/strict';
-import { context, msg } from '../src/helpers.ts';
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { context, msg } from "../src/helpers.ts";
 
-test('context builder attaches context to msg', () => {
-  const verb = context('verb');
-  assert.deepEqual(verb.msg('Open'), { context: 'verb', id: { msgid: 'Open', msgstr: 'Open' } });
+test("context builder attaches context to msg", () => {
+	const verb = context("verb");
+	assert.deepEqual(verb.msg("Open"), {
+		context: "verb",
+		id: { msgid: "Open", msgstr: "Open" },
+	});
 });
 
-test('context builder attaches context to plural', () => {
-  const company = context('company');
-  const p = company.plural(msg`${0} apple`, msg`${0} apples`, 2);
-  assert.equal(p.context, 'company');
-  assert.equal(p.id.forms[0].msgstr, '${0} apple');
-  assert.equal(p.id.forms[1].msgstr, '${0} apples');
+test("context builder attaches context to plural", () => {
+	const company = context("company");
+	const p = company.plural(msg`${0} apple`, msg`${0} apples`, 2);
+	assert.equal(p.context, "company");
+	assert.equal(p.id.forms[0].msgstr, "${0} apple");
+	assert.equal(p.id.forms[1].msgstr, "${0} apples");
 });

--- a/packages/translate/test/gettext.test.ts
+++ b/packages/translate/test/gettext.test.ts
@@ -1,27 +1,27 @@
-import { test } from 'node:test';
-import assert from 'node:assert/strict';
-import { msg } from '../src/helpers.ts';
-import { Translator } from '../src/translator.ts';
-import fs from 'node:fs';
-import * as gettextParser from 'gettext-parser';
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { msg } from "../src/helpers.ts";
+import { Translator } from "../src/translator.ts";
+import fs from "node:fs";
+import * as gettextParser from "gettext-parser";
 
-test('translator substitutes template values', () => {
-  const name = 'World';
-  const t = new Translator('en', {});
-  assert.equal(t.gettext(msg`Hello, ${name}!`), 'Hello, World!');
+test("translator substitutes template values", () => {
+	const name = "World";
+	const t = new Translator("en", {});
+	assert.equal(t.gettext(msg`Hello, ${name}!`), "Hello, World!");
 });
 
-test('translator applies translations with placeholders', () => {
-  const name = 'World';
-  const ruPo = fs.readFileSync(new URL('./fixtures/ru.po', import.meta.url));
-  const translations = { ru: gettextParser.po.parse(ruPo) };
-  const t = new Translator('en', translations);
-  t.useLocale('ru');
-  assert.equal(t.gettext`Hello, ${name}!`, 'Привет, World!');
+test("translator applies translations with placeholders", () => {
+	const name = "World";
+	const ruPo = fs.readFileSync(new URL("./fixtures/ru.po", import.meta.url));
+	const translations = { ru: gettextParser.po.parse(ruPo) };
+	const t = new Translator("en", translations);
+	t.useLocale("ru");
+	assert.equal(t.gettext`Hello, ${name}!`, "Привет, World!");
 });
 
-test('gettext returns original string when translation missing', () => {
-  const t = new Translator('en', {});
-  t.useLocale('fr');
-  assert.equal(t.gettext(msg`Untranslated`), 'Untranslated');
+test("gettext returns original string when translation missing", () => {
+	const t = new Translator("en", {});
+	t.useLocale("fr");
+	assert.equal(t.gettext(msg`Untranslated`), "Untranslated");
 });

--- a/packages/translate/test/msg.test.ts
+++ b/packages/translate/test/msg.test.ts
@@ -1,44 +1,50 @@
-import { test } from 'node:test';
-import assert from 'node:assert/strict';
+import { test } from "node:test";
+import assert from "node:assert/strict";
 
-import { msg } from '../src/helpers.ts';
+import { msg } from "../src/helpers.ts";
 
-test('msg with string returns id and message', () => {
-  assert.deepEqual(msg('hello'), { msgid: 'hello', msgstr: 'hello' });
+test("msg with string returns id and message", () => {
+	assert.deepEqual(msg("hello"), { msgid: "hello", msgstr: "hello" });
 });
 
-test('msg with descriptor uses id and message', () => {
-  const descriptor = { id: 'greeting', message: 'Hello world' };
-  assert.deepEqual(msg(descriptor), { msgid: 'greeting', msgstr: 'Hello world' });
+test("msg with descriptor uses id and message", () => {
+	const descriptor = { id: "greeting", message: "Hello world" };
+	assert.deepEqual(msg(descriptor), {
+		msgid: "greeting",
+		msgstr: "Hello world",
+	});
 });
 
-test('msg with descriptor id only uses it for message too', () => {
-  const descriptor = { id: 'onlyId' };
-  assert.deepEqual(msg(descriptor), { msgid: 'onlyId', msgstr: 'onlyId' });
+test("msg with descriptor id only uses it for message too", () => {
+	const descriptor = { id: "onlyId" };
+	assert.deepEqual(msg(descriptor), { msgid: "onlyId", msgstr: "onlyId" });
 });
 
-test('msg with descriptor message only uses it for id too', () => {
-  const descriptor = { message: 'onlyMessage' };
-  assert.deepEqual(msg(descriptor), { msgid: 'onlyMessage', msgstr: 'onlyMessage' });
+test("msg with descriptor message only uses it for id too", () => {
+	const descriptor = { message: "onlyMessage" };
+	assert.deepEqual(msg(descriptor), {
+		msgid: "onlyMessage",
+		msgstr: "onlyMessage",
+	});
 });
 
-test('msg with template string returns placeholders and values', () => {
-  const name = 'World';
-  assert.deepEqual(msg`Hello, ${name}!`, {
-    msgid: 'Hello, ${0}!',
-    msgstr: 'Hello, ${0}!',
-    values: [name],
-  });
+test("msg with template string returns placeholders and values", () => {
+	const name = "World";
+	assert.deepEqual(msg`Hello, ${name}!`, {
+		msgid: "Hello, ${0}!",
+		msgstr: "Hello, ${0}!",
+		values: [name],
+	});
 });
 
-test('msg disallows computed strings', () => {
-  const variable: string = 'v';
-  // @ts-expect-error computed strings are not allowed
-  msg('Computed' + variable + 'string');
+test("msg disallows computed strings", () => {
+	const variable: string = "v";
+	// @ts-expect-error computed strings are not allowed
+	msg("Computed" + variable + "string");
 });
 
-test('msg disallows variables', () => {
-  let name = 'World';
-  // @ts-expect-error dynamic template strings are not allowed
-  msg(name);
+test("msg disallows variables", () => {
+	let name = "World";
+	// @ts-expect-error dynamic template strings are not allowed
+	msg(name);
 });

--- a/packages/translate/test/ngettext.test.ts
+++ b/packages/translate/test/ngettext.test.ts
@@ -1,79 +1,90 @@
-import { test } from 'node:test';
-import assert from 'node:assert/strict';
-import { msg, plural, context } from '../src/helpers.ts';
-import { Translator } from '../src/translator.ts';
-import fs from 'node:fs';
-import * as gettextParser from 'gettext-parser';
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { msg, plural, context } from "../src/helpers.ts";
+import { Translator } from "../src/translator.ts";
+import fs from "node:fs";
+import * as gettextParser from "gettext-parser";
 
 function load(locale: string) {
-  const po = fs.readFileSync(new URL(`./fixtures/${locale}.po`, import.meta.url));
-  return gettextParser.po.parse(po);
+	const po = fs.readFileSync(
+		new URL(`./fixtures/${locale}.po`, import.meta.url),
+	);
+	return gettextParser.po.parse(po);
 }
 
 const translations = {
-  en: load('en'),
-  ru: load('ru'),
+	en: load("en"),
+	ru: load("ru"),
 };
 
-test('ngettext handles English plurals', () => {
-  const t = new Translator('en', translations);
-  assert.equal(t.ngettext(msg`${1} apple`, msg`${1} apples`, 1), '1 apple');
-  assert.equal(t.ngettext(msg`${2} apple`, msg`${2} apples`, 2), '2 apples');
+test("ngettext handles English plurals", () => {
+	const t = new Translator("en", translations);
+	assert.equal(t.ngettext(msg`${1} apple`, msg`${1} apples`, 1), "1 apple");
+	assert.equal(t.ngettext(msg`${2} apple`, msg`${2} apples`, 2), "2 apples");
 });
 
-test('ngettext handles Russian plurals', () => {
-  const t = new Translator('en', translations);
-  t.useLocale('ru');
-  assert.equal(t.ngettext(msg`${1} apple`, msg`${1} apples`, 1), '1 яблоко');
-  assert.equal(t.ngettext(msg`${2} apple`, msg`${2} apples`, 2), '2 яблока');
-  assert.equal(t.ngettext(msg`${5} apple`, msg`${5} apples`, 5), '5 яблок');
+test("ngettext handles Russian plurals", () => {
+	const t = new Translator("en", translations);
+	t.useLocale("ru");
+	assert.equal(t.ngettext(msg`${1} apple`, msg`${1} apples`, 1), "1 яблоко");
+	assert.equal(t.ngettext(msg`${2} apple`, msg`${2} apples`, 2), "2 яблока");
+	assert.equal(t.ngettext(msg`${5} apple`, msg`${5} apples`, 5), "5 яблок");
 });
 
-test('ngettext supports plural helper', () => {
-  const t = new Translator('en', translations);
-  const apples = plural(msg`${1} apple`, msg`${1} apples`, 1);
-  assert.equal(t.ngettext(apples), '1 apple');
+test("ngettext supports plural helper", () => {
+	const t = new Translator("en", translations);
+	const apples = plural(msg`${1} apple`, msg`${1} apples`, 1);
+	assert.equal(t.ngettext(apples), "1 apple");
 });
 
-test('ngettext supports plural helper with multiple forms', () => {
-  const t = new Translator('ru', translations);
-  const apples = plural(msg`${5} apple`, msg`${5} apples`, msg`${5} many apples`, 5);
-  assert.equal(t.ngettext(apples), '5 яблок');
+test("ngettext supports plural helper with multiple forms", () => {
+	const t = new Translator("ru", translations);
+	const apples = plural(
+		msg`${5} apple`,
+		msg`${5} apples`,
+		msg`${5} many apples`,
+		5,
+	);
+	assert.equal(t.ngettext(apples), "5 яблок");
 });
 
-test('ngettext substitutes values from the chosen plural form', () => {
-  const t = new Translator('en', translations);
-  assert.equal(
-    t.ngettext(msg`${'Bob'} ${1} carrot`, msg`${2} carrots for ${'Bob'}`, 1),
-    'Bob 1 carrot',
-  );
-  assert.equal(
-    t.ngettext(msg`${'Bob'} ${1} carrot`, msg`${2} carrots for ${'Bob'}`, 2),
-    '2 carrots for Bob',
-  );
+test("ngettext substitutes values from the chosen plural form", () => {
+	const t = new Translator("en", translations);
+	assert.equal(
+		t.ngettext(msg`${"Bob"} ${1} carrot`, msg`${2} carrots for ${"Bob"}`, 1),
+		"Bob 1 carrot",
+	);
+	assert.equal(
+		t.ngettext(msg`${"Bob"} ${1} carrot`, msg`${2} carrots for ${"Bob"}`, 2),
+		"2 carrots for Bob",
+	);
 });
 
-test('npgettext handles context with plurals', () => {
-  const t = new Translator('ru', translations);
-  assert.equal(
-    t.npgettext('company', msg`${1} apple`, msg`${1} apples`, 1),
-    '1 Apple устройство'
-  );
-  assert.equal(
-    t.npgettext('company', msg`${2} apple`, msg`${2} apples`, 2),
-    '2 Apple устройства'
-  );
+test("npgettext handles context with plurals", () => {
+	const t = new Translator("ru", translations);
+	assert.equal(
+		t.npgettext("company", msg`${1} apple`, msg`${1} apples`, 1),
+		"1 Apple устройство",
+	);
+	assert.equal(
+		t.npgettext("company", msg`${2} apple`, msg`${2} apples`, 2),
+		"2 Apple устройства",
+	);
 });
 
-test('ngettext handles context-aware plural helper', () => {
-  const t = new Translator('ru', translations);
-  const apples = context('company').plural(msg`${2} apple`, msg`${2} apples`, 2);
-  assert.equal(t.npgettext(apples), '2 Apple устройства');
+test("ngettext handles context-aware plural helper", () => {
+	const t = new Translator("ru", translations);
+	const apples = context("company").plural(
+		msg`${2} apple`,
+		msg`${2} apples`,
+		2,
+	);
+	assert.equal(t.npgettext(apples), "2 Apple устройства");
 });
 
-test('ngettext returns default forms when translation missing', () => {
-  const t = new Translator('en', {});
-  t.useLocale('fr');
-  assert.equal(t.ngettext(msg`${1} apple`, msg`${1} apples`, 1), '1 apple');
-  assert.equal(t.ngettext(msg`${2} apple`, msg`${2} apples`, 2), '2 apples');
+test("ngettext returns default forms when translation missing", () => {
+	const t = new Translator("en", {});
+	t.useLocale("fr");
+	assert.equal(t.ngettext(msg`${1} apple`, msg`${1} apples`, 1), "1 apple");
+	assert.equal(t.ngettext(msg`${2} apple`, msg`${2} apples`, 2), "2 apples");
 });

--- a/packages/translate/test/npgettext.test.ts
+++ b/packages/translate/test/npgettext.test.ts
@@ -1,60 +1,66 @@
-import { test } from 'node:test';
-import assert from 'node:assert/strict';
-import { context, msg } from '../src/helpers.ts';
-import { Translator } from '../src/translator.ts';
-import fs from 'node:fs';
-import * as gettextParser from 'gettext-parser';
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { context, msg } from "../src/helpers.ts";
+import { Translator } from "../src/translator.ts";
+import fs from "node:fs";
+import * as gettextParser from "gettext-parser";
 
 function load(locale: string) {
-    const po = fs.readFileSync(new URL(`./fixtures/${locale}.po`, import.meta.url));
-    return gettextParser.po.parse(po);
+	const po = fs.readFileSync(
+		new URL(`./fixtures/${locale}.po`, import.meta.url),
+	);
+	return gettextParser.po.parse(po);
 }
 
 const translations = {
-    en: load('en'),
-    ru: load('ru'),
+	en: load("en"),
+	ru: load("ru"),
 };
 
-test('ngettext handles context-aware message pairs', () => {
-    const t = new Translator('ru', translations);
-    assert.equal(
-        t.npgettext('company', msg`${1} apple`, msg`${1} apples`, 1),
-        '1 Apple устройство'
-    );
-    assert.equal(
-        t.npgettext('company', msg`${2} apple`, msg`${2} apples`, 2),
-        '2 Apple устройства'
-    );
+test("ngettext handles context-aware message pairs", () => {
+	const t = new Translator("ru", translations);
+	assert.equal(
+		t.npgettext("company", msg`${1} apple`, msg`${1} apples`, 1),
+		"1 Apple устройство",
+	);
+	assert.equal(
+		t.npgettext("company", msg`${2} apple`, msg`${2} apples`, 2),
+		"2 Apple устройства",
+	);
 });
 
-test('pgettext and npgettext accept context-aware messages', () => {
-    const t = new Translator('ru', translations);
-    const verb = context('verb');
-    assert.equal(t.pgettext(verb.msg('Open')), 'Открыть');
-    const apples = context('company').plural(msg`${3} apple`, msg`${3} apples`, 3);
-    assert.equal(t.npgettext(apples), '3 Apple устройства');
+test("pgettext and npgettext accept context-aware messages", () => {
+	const t = new Translator("ru", translations);
+	const verb = context("verb");
+	assert.equal(t.pgettext(verb.msg("Open")), "Открыть");
+	const apples = context("company").plural(
+		msg`${3} apple`,
+		msg`${3} apples`,
+		3,
+	);
+	assert.equal(t.npgettext(apples), "3 Apple устройства");
 });
 
-test('npgettext substitutes values from the chosen plural form', () => {
-    const t = new Translator('en', translations);
-    assert.equal(
-        t.npgettext('ctx', msg`${1} apple`, msg`${2} apples for ${'Bob'}`, 1),
-        '1 apple',
-    );
-    assert.equal(
-        t.npgettext('ctx', msg`${1} apple`, msg`${2} apples for ${'Bob'}`, 2),
-        '2 apples for Bob',
-    );
+test("npgettext substitutes values from the chosen plural form", () => {
+	const t = new Translator("en", translations);
+	assert.equal(
+		t.npgettext("ctx", msg`${1} apple`, msg`${2} apples for ${"Bob"}`, 1),
+		"1 apple",
+	);
+	assert.equal(
+		t.npgettext("ctx", msg`${1} apple`, msg`${2} apples for ${"Bob"}`, 2),
+		"2 apples for Bob",
+	);
 });
 
-test('npgettext returns default forms when translation missing', () => {
-    const t = new Translator('ru', translations);
-    assert.equal(
-        t.npgettext('company', msg`${1} pear`, msg`${1} pears`, 1),
-        '1 pear',
-    );
-    assert.equal(
-        t.npgettext('company', msg`${2} pear`, msg`${2} pears`, 2),
-        '2 pears',
-    );
+test("npgettext returns default forms when translation missing", () => {
+	const t = new Translator("ru", translations);
+	assert.equal(
+		t.npgettext("company", msg`${1} pear`, msg`${1} pears`, 1),
+		"1 pear",
+	);
+	assert.equal(
+		t.npgettext("company", msg`${2} pear`, msg`${2} pears`, 2),
+		"2 pears",
+	);
 });

--- a/packages/translate/test/pgettext.test.ts
+++ b/packages/translate/test/pgettext.test.ts
@@ -1,30 +1,30 @@
-import { test } from 'node:test';
-import assert from 'node:assert/strict';
-import { context } from '../src/helpers.ts';
-import { Translator } from '../src/translator.ts';
-import fs from 'node:fs';
-import * as gettextParser from 'gettext-parser';
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { context } from "../src/helpers.ts";
+import { Translator } from "../src/translator.ts";
+import fs from "node:fs";
+import * as gettextParser from "gettext-parser";
 
-test('pgettext handles context-specific translations', () => {
-  const ruPo = fs.readFileSync(new URL('./fixtures/ru.po', import.meta.url));
-  const translations = { ru: gettextParser.po.parse(ruPo) };
-  const t = new Translator('ru', translations);
-  assert.equal(t.pgettext('verb', "Open"), 'Открыть');
-  assert.equal(t.pgettext('adjective', "Open"), 'Открытый');
+test("pgettext handles context-specific translations", () => {
+	const ruPo = fs.readFileSync(new URL("./fixtures/ru.po", import.meta.url));
+	const translations = { ru: gettextParser.po.parse(ruPo) };
+	const t = new Translator("ru", translations);
+	assert.equal(t.pgettext("verb", "Open"), "Открыть");
+	assert.equal(t.pgettext("adjective", "Open"), "Открытый");
 });
 
-test('gettext handles context-aware messages', () => {
-  const ruPo = fs.readFileSync(new URL('./fixtures/ru.po', import.meta.url));
-  const translations = { ru: gettextParser.po.parse(ruPo) };
-  const t = new Translator('en', translations);
-  t.useLocale('ru');
-  const verb = context('verb');
-  assert.equal(t.pgettext(verb.msg('Open')), 'Открыть');
+test("gettext handles context-aware messages", () => {
+	const ruPo = fs.readFileSync(new URL("./fixtures/ru.po", import.meta.url));
+	const translations = { ru: gettextParser.po.parse(ruPo) };
+	const t = new Translator("en", translations);
+	t.useLocale("ru");
+	const verb = context("verb");
+	assert.equal(t.pgettext(verb.msg("Open")), "Открыть");
 });
 
-test('pgettext returns original string when translation missing', () => {
-  const ruPo = fs.readFileSync(new URL('./fixtures/ru.po', import.meta.url));
-  const translations = { ru: gettextParser.po.parse(ruPo) };
-  const t = new Translator('ru', translations);
-  assert.equal(t.pgettext('verb', 'Close'), 'Close');
+test("pgettext returns original string when translation missing", () => {
+	const ruPo = fs.readFileSync(new URL("./fixtures/ru.po", import.meta.url));
+	const translations = { ru: gettextParser.po.parse(ruPo) };
+	const t = new Translator("ru", translations);
+	assert.equal(t.pgettext("verb", "Close"), "Close");
 });

--- a/packages/translate/test/plural.test.ts
+++ b/packages/translate/test/plural.test.ts
@@ -1,17 +1,36 @@
-import { test } from 'node:test';
-import assert from 'node:assert/strict';
+import { test } from "node:test";
+import assert from "node:assert/strict";
 
-import { msg, plural } from '../src/helpers.ts';
+import { msg, plural } from "../src/helpers.ts";
 
-test('msg with string returns id and message', () => {
-  assert.deepEqual(plural(msg("hello"), 1), { forms: [{ msgid: 'hello', msgstr: 'hello' }], n: 1 });
+test("msg with string returns id and message", () => {
+	assert.deepEqual(plural(msg("hello"), 1), {
+		forms: [{ msgid: "hello", msgstr: "hello" }],
+		n: 1,
+	});
 });
 
-test('plural supports arbitrary number of forms', () => {
-  const forms = plural(msg`${0} apple`, msg`${0} apples`, msg`${0} many apples`, 3);
-  assert.deepEqual(forms.forms[0], { msgid: '${0} apple', msgstr: '${0} apple', values: [0] });
-  assert.deepEqual(forms.forms[1], { msgid: '${0} apples', msgstr: '${0} apples', values: [0] });
-  assert.deepEqual(forms.forms[2], { msgid: '${0} many apples', msgstr: '${0} many apples', values: [0] });
-  assert.equal(forms.n, 3);
+test("plural supports arbitrary number of forms", () => {
+	const forms = plural(
+		msg`${0} apple`,
+		msg`${0} apples`,
+		msg`${0} many apples`,
+		3,
+	);
+	assert.deepEqual(forms.forms[0], {
+		msgid: "${0} apple",
+		msgstr: "${0} apple",
+		values: [0],
+	});
+	assert.deepEqual(forms.forms[1], {
+		msgid: "${0} apples",
+		msgstr: "${0} apples",
+		values: [0],
+	});
+	assert.deepEqual(forms.forms[2], {
+		msgid: "${0} many apples",
+		msgstr: "${0} many apples",
+		values: [0],
+	});
+	assert.equal(forms.n, 3);
 });
-

--- a/packages/translate/test/utils.test.ts
+++ b/packages/translate/test/utils.test.ts
@@ -1,30 +1,32 @@
-import { test } from 'node:test';
-import assert from 'node:assert/strict';
+import { test } from "node:test";
+import assert from "node:assert/strict";
 
-import { substitute, memo, pluralFunc } from '../src/utils.ts';
-
+import { substitute, memo, pluralFunc } from "../src/utils.ts";
 
 // substitute replacement behavior
-test('substitute replaces placeholders with values', () => {
-  assert.equal(substitute('Hello ${0}, ${1}!', ['World', 'Friend']), 'Hello World, Friend!');
+test("substitute replaces placeholders with values", () => {
+	assert.equal(
+		substitute("Hello ${0}, ${1}!", ["World", "Friend"]),
+		"Hello World, Friend!",
+	);
 });
 
 // memo caching behavior
-test('memo caches results for same inputs', () => {
-  let calls = 0;
-  const fn = memo((x: number) => {
-    calls++;
-    return x * 2;
-  });
+test("memo caches results for same inputs", () => {
+	let calls = 0;
+	const fn = memo((x: number) => {
+		calls++;
+		return x * 2;
+	});
 
-  assert.equal(fn(2), 4);
-  assert.equal(fn(2), 4);
-  assert.equal(calls, 1);
+	assert.equal(fn(2), 4);
+	assert.equal(fn(2), 4);
+	assert.equal(calls, 1);
 });
 
 // pluralFunc default behavior for unknown locale
-test('pluralFunc falls back to default when locale is unknown', () => {
-  const pf = pluralFunc('xx');
-  assert.equal(pf(1), 0);
-  assert.equal(pf(2), 1);
+test("pluralFunc falls back to default when locale is unknown", () => {
+	const pf = pluralFunc("xx");
+	assert.equal(pf(1), 0);
+	assert.equal(pf(2), 1);
 });

--- a/packages/translate/tsconfig.json
+++ b/packages/translate/tsconfig.json
@@ -1,3 +1,3 @@
 {
-  "extends": "../../tsconfig.json",
+	"extends": "../../tsconfig.json"
 }


### PR DESCRIPTION
## Summary
- replace oxlint with @biomejs/biome for linting and formatting
- configure Biome via `biome.json`
- format codebase using Biome

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b43eb98740832faa15c67a4047f634