### PR TITLE
feat: add gettext query support

### DIFF
--- a/packages/extract/src/queries/gettext.ts
+++ b/packages/extract/src/queries/gettext.ts
@@ -1,0 +1,155 @@
+import { withComment } from "./comment.ts";
+import type { QuerySpec } from "./types.ts";
+
+const gettextCall = (args: string) => `(
+  (call_expression
+    function: [
+      (identifier) @func
+      (member_expression property: (property_identifier) @func)
+    ]
+    arguments: ${args}
+  ) @call
+  (#eq? @func "gettext")
+)`;
+
+export const gettextStringQuery: QuerySpec = withComment({
+    pattern: gettextCall(`(arguments
+    (string (string_fragment) @msgid)
+)`),
+    extract(match) {
+        const node = match.captures.find((c) => c.name === "call")?.node;
+        if (!node) {
+            return undefined;
+        }
+
+        const msgid = match.captures.find((c) => c.name === "msgid")?.node.text;
+        if (!msgid) {
+            return undefined;
+        }
+
+        return {
+            node,
+            translation: {
+                msgid,
+                msgstr: [msgid],
+            },
+        };
+    },
+});
+
+export const gettextDescriptorQuery: QuerySpec = withComment({
+    pattern: gettextCall(`(arguments
+        (object
+                (_)*
+                (pair
+                key: (property_identifier) @id_key
+                value: (string (string_fragment) @id)
+                (#eq? @id_key "id")
+                )?
+                (_)*
+                (pair
+                key: (property_identifier) @msg_key
+                value: (string (string_fragment) @message)
+                (#eq? @msg_key "message")
+                )?
+                (_)*
+        )
+)`),
+    extract(match) {
+        const node = match.captures.find((c) => c.name === "call")?.node;
+        if (!node) {
+            return undefined;
+        }
+
+        const id = match.captures.find((c) => c.name === "id")?.node.text;
+        const message = match.captures.find((c) => c.name === "message")?.node.text;
+        const msgid = id ?? message;
+        if (!msgid) {
+            return undefined;
+        }
+
+        const msgstr = message ?? id ?? "";
+
+        return {
+            node,
+            translation: {
+                msgid,
+                msgstr: [msgstr],
+            },
+        };
+    },
+});
+
+export const gettextTemplateQuery: QuerySpec = withComment({
+    pattern: gettextCall(`[
+        (template_string) @tpl
+        (arguments (
+            call_expression
+                function: (identifier) @msgfn
+                arguments: (template_string) @tpl
+                (#eq? @msgfn "msg")
+        ))
+    ]`),
+    extract(match) {
+        const node = match.captures.find((c) => c.name === "call")?.node;
+        if (!node) {
+            return undefined;
+        }
+
+        const tpl = match.captures.find((c) => c.name === "tpl")?.node;
+        if (!tpl) {
+            return undefined;
+        }
+
+        for (const child of tpl.children) {
+            if (child.type !== "template_substitution") {
+                continue;
+            }
+
+            const expr = child.namedChildren[0];
+            if (!expr || expr.type !== "identifier") {
+                return {
+                    node,
+                    error: "gettext() template expressions must be simple identifiers",
+                };
+            }
+        }
+
+        const text = tpl.text.slice(1, -1);
+
+        return {
+            node,
+            translation: { msgid: text, msgstr: [text] },
+        };
+    },
+});
+
+const allowed = new Set([
+    "string",
+    "object",
+    "template_string",
+    "identifier",
+    "call_expression",
+]);
+
+export const gettextInvalidQuery: QuerySpec = {
+    pattern: gettextCall(`(arguments (_) @arg)`),
+    extract(match) {
+        const call = match.captures.find((c) => c.name === "call")?.node;
+        const node = match.captures.find((c) => c.name === "arg")?.node;
+
+        if (!call || !node) {
+            return undefined;
+        }
+
+        if (allowed.has(node.type)) {
+            return undefined;
+        }
+
+        return {
+            node,
+            error: "gettext() argument must be a string literal, object literal, or template literal",
+        };
+    },
+};
+

--- a/packages/extract/src/queries/index.ts
+++ b/packages/extract/src/queries/index.ts
@@ -1,6 +1,26 @@
-import { msgDescriptorQuery, msgInvalidQuery, msgStringQuery, msgTemplateQuery } from "./msg.ts";
+import {
+    msgDescriptorQuery,
+    msgInvalidQuery,
+    msgStringQuery,
+    msgTemplateQuery,
+} from "./msg.ts";
+import {
+    gettextDescriptorQuery,
+    gettextInvalidQuery,
+    gettextStringQuery,
+    gettextTemplateQuery,
+} from "./gettext.ts";
 import type { QuerySpec } from "./types.ts";
 
 export type { MessageMatch, QuerySpec } from "./types.ts";
 
-export const queries: QuerySpec[] = [msgStringQuery, msgDescriptorQuery, msgTemplateQuery, msgInvalidQuery];
+export const queries: QuerySpec[] = [
+    msgStringQuery,
+    msgDescriptorQuery,
+    msgTemplateQuery,
+    msgInvalidQuery,
+    gettextStringQuery,
+    gettextDescriptorQuery,
+    gettextTemplateQuery,
+    gettextInvalidQuery,
+];

--- a/packages/extract/src/queries/tests/fixtures/gettext.ts
+++ b/packages/extract/src/queries/tests/fixtures/gettext.ts
@@ -1,0 +1,34 @@
+import { msg } from "@let-value/translate";
+
+const t = { gettext: (v) => v };
+
+t.gettext("hello");
+
+// comment
+t.gettext("hello comment");
+
+// descriptor
+t.gettext({ id: "greeting", message: "Hello, world!" });
+
+/* multiline
+ * comment */
+t.gettext({ id: "greeting", message: "Hello, world!" });
+
+const name = "World";
+t.gettext`Hello, ${name}!`;
+
+const helloMsg = msg`Hi, ${name}!`;
+t.gettext(helloMsg);
+
+function getGreeting() {
+    return helloMsg;
+}
+// deferred message via function call
+t.gettext(getGreeting());
+// @ts-expect-error invalid call
+// biome-ignore lint/style/useTemplate: true
+t.gettext("Hi, " + name);
+
+t.gettext`Hi, ${getGreeting()}!`;
+
+t.gettext`Hi, ${name.length}!`;

--- a/packages/extract/src/queries/tests/gettext.test.ts
+++ b/packages/extract/src/queries/tests/gettext.test.ts
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { suite, test } from "node:test";
+import {
+    gettextDescriptorQuery,
+    gettextInvalidQuery,
+    gettextStringQuery,
+    gettextTemplateQuery,
+} from "../gettext.ts";
+import { msgTemplateQuery } from "../msg.ts";
+import { getMatches } from "./utils.ts";
+
+const fixture = readFileSync(new URL("./fixtures/gettext.ts", import.meta.url)).toString();
+
+const paths = ["test.js", "test.jsx", "test.ts", "test.tsx"];
+
+suite("should extract string message", () =>
+    paths.forEach((path) => {
+        test(path, () => {
+            const matches = getMatches(fixture, path, gettextStringQuery);
+            const translations = matches.map(({ translation }) => translation);
+
+            assert.equal(translations.length, 2);
+            assert.deepEqual(translations, [
+                {
+                    msgid: "hello",
+                    msgstr: ["hello"],
+                },
+                {
+                    msgid: "hello comment",
+                    msgstr: ["hello comment"],
+                    comments: {
+                        extracted: "comment",
+                    },
+                },
+            ]);
+        });
+    }),
+);
+
+suite("should extract descriptor message", () =>
+    paths.forEach((path) => {
+        test(path, () => {
+            const matches = getMatches(fixture, path, gettextDescriptorQuery);
+
+            assert.equal(matches.length, 2);
+            assert.deepEqual(
+                matches.map(({ translation }) => translation),
+                [
+                    {
+                        msgid: "greeting",
+                        msgstr: ["Hello, world!"],
+                        comments: {
+                            extracted: "descriptor",
+                        },
+                    },
+                    {
+                        msgid: "greeting",
+                        msgstr: ["Hello, world!"],
+                        comments: {
+                            extracted: "multiline\ncomment",
+                        },
+                    },
+                ],
+            );
+        });
+    }),
+);
+
+suite("should extract template message", () =>
+    paths.forEach((path) => {
+        test(path, () => {
+            const matches = getMatches(fixture, path, gettextTemplateQuery);
+
+            assert.equal(matches.length, 3);
+            assert.deepEqual(
+                matches.map(({ translation, error }) => ({
+                    error,
+                    translation,
+                })),
+                [
+                    {
+                        error: undefined,
+                        translation: {
+                            msgid: "Hello, ${name}!",
+                            msgstr: ["Hello, ${name}!"],
+                        },
+                    },
+                    {
+                        error: "gettext() template expressions must be simple identifiers",
+                        translation: undefined,
+                    },
+                    {
+                        error: "gettext() template expressions must be simple identifiers",
+                        translation: undefined,
+                    },
+                ],
+            );
+        });
+    }),
+);
+
+suite("should extract errors", () =>
+    paths.forEach((path) => {
+        test(path, () => {
+            const matches = getMatches(fixture, path, gettextInvalidQuery);
+
+            assert.deepEqual(
+                matches.map(({ error, translation }) => ({
+                    error,
+                    translation,
+                })),
+                [
+                    {
+                        error: "gettext() argument must be a string literal, object literal, or template literal",
+                        translation: undefined,
+                    },
+                ],
+            );
+        });
+    }),
+);
+
+suite("should handle combined usage with msg", () =>
+    paths.forEach((path) => {
+        test(path, () => {
+            const source = `import { msg } from "@let-value/translate";\nconst t = { gettext: (v) => v };\nconst name = "World";\nt.gettext(msg\`Hello, \${name}!\`);`;
+            const msgMatches = getMatches(source, path, msgTemplateQuery);
+            const gettextMatches = getMatches(source, path, gettextTemplateQuery);
+            const invalidMatches = getMatches(source, path, gettextInvalidQuery);
+            assert.equal(msgMatches.length, 0);
+            assert.equal(gettextMatches.length, 1);
+            assert.equal(invalidMatches.length, 0);
+        });
+    }),
+);


### PR DESCRIPTION
## Summary
- add Tree-sitter queries for `gettext` invocations
- handle `gettext` + `msg` usage without duplicate extraction
- allow deferred `msg` calls via function expressions without warnings
- test `gettext` extraction and mixed usage with `msg`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5aacad610832f958ff1bc34b9a52f