### PR TITLE
feat: combine msg queries

### DIFF
--- a/packages/extract/src/queries/index.ts
+++ b/packages/extract/src/queries/index.ts
@@ -1,13 +1,11 @@
 import { gettextDescriptorQuery, gettextInvalidQuery, gettextStringQuery, gettextTemplateQuery } from "./gettext.ts";
-import { msgDescriptorQuery, msgInvalidQuery, msgStringQuery, msgTemplateQuery } from "./msg.ts";
+import { msgInvalidQuery, msgQuery } from "./msg.ts";
 import type { QuerySpec } from "./types.ts";
 
 export type { MessageMatch, QuerySpec } from "./types.ts";
 
 export const queries: QuerySpec[] = [
-    msgStringQuery,
-    msgDescriptorQuery,
-    msgTemplateQuery,
+    msgQuery,
     msgInvalidQuery,
     gettextStringQuery,
     gettextDescriptorQuery,

--- a/packages/extract/src/queries/tests/gettext.test.ts
+++ b/packages/extract/src/queries/tests/gettext.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { suite, test } from "node:test";
 import { gettextDescriptorQuery, gettextInvalidQuery, gettextStringQuery, gettextTemplateQuery } from "../gettext.ts";
-import { msgTemplateQuery } from "../msg.ts";
+import { msgQuery } from "../msg.ts";
 import { getMatches } from "./utils.ts";
 
 const fixture = readFileSync(new URL("./fixtures/gettext.ts", import.meta.url)).toString();
@@ -120,7 +120,7 @@ suite("should handle combined usage with msg", () =>
     paths.forEach((path) => {
         test(path, () => {
             const source = `import { msg } from "@let-value/translate";\nconst t = { gettext: (v) => v };\nconst name = "World";\nt.gettext(msg\`Hello, \${name}!\`);`;
-            const msgMatches = getMatches(source, path, msgTemplateQuery);
+            const msgMatches = getMatches(source, path, msgQuery);
             const gettextMatches = getMatches(source, path, gettextTemplateQuery);
             const invalidMatches = getMatches(source, path, gettextInvalidQuery);
             assert.equal(msgMatches.length, 0);

--- a/packages/extract/src/queries/tests/msg.test.ts
+++ b/packages/extract/src/queries/tests/msg.test.ts
@@ -1,78 +1,58 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { suite, test } from "node:test";
-import { msgDescriptorQuery, msgInvalidQuery, msgStringQuery, msgTemplateQuery } from "../msg.ts";
+import { msgInvalidQuery, msgQuery } from "../msg.ts";
 import { getMatches } from "./utils.ts";
 
 const fixture = readFileSync(new URL("./fixtures/msg.ts", import.meta.url)).toString();
 
 const paths = ["test.js", "test.jsx", "test.ts", "test.tsx"];
 
-suite("should extract string message", () =>
+suite("should extract messages", () =>
     paths.forEach((path) => {
         test(path, () => {
-            const matches = getMatches(fixture, path, msgStringQuery);
-            const translations = matches.map(({ translation }) => translation);
+            const matches = getMatches(fixture, path, msgQuery);
 
-            assert.equal(translations.length, 2);
-            assert.deepEqual(translations, [
-                {
-                    msgid: "hello",
-                    msgstr: ["hello"],
-                },
-                {
-                    msgid: "hello comment",
-                    msgstr: ["hello comment"],
-                    comments: {
-                        extracted: "comment",
-                    },
-                },
-            ]);
-        });
-    }),
-);
-
-suite("should extract descriptor message", () =>
-    paths.forEach((path) => {
-        test(path, () => {
-            const matches = getMatches(fixture, path, msgDescriptorQuery);
-
-            assert.equal(matches.length, 2);
             assert.deepEqual(
-                matches.map(({ translation }) => translation),
+                matches.map(({ translation, error }) => ({ translation, error })),
                 [
                     {
-                        msgid: "greeting",
-                        msgstr: ["Hello, world!"],
-                        comments: {
-                            extracted: "descriptor",
+                        error: undefined,
+                        translation: {
+                            msgid: "hello",
+                            msgstr: ["hello"],
                         },
                     },
                     {
-                        msgid: "greeting",
-                        msgstr: ["Hello, world!"],
-                        comments: {
-                            extracted: "multiline\ncomment",
+                        error: undefined,
+                        translation: {
+                            msgid: "hello comment",
+                            msgstr: ["hello comment"],
+                            comments: {
+                                extracted: "comment",
+                            },
                         },
                     },
-                ],
-            );
-        });
-    }),
-);
-
-suite("should extract template message", () =>
-    paths.forEach((path) => {
-        test(path, () => {
-            const matches = getMatches(fixture, path, msgTemplateQuery);
-
-            assert.equal(matches.length, 3);
-            assert.deepEqual(
-                matches.map(({ translation, error }) => ({
-                    error,
-                    translation,
-                })),
-                [
+                    {
+                        error: undefined,
+                        translation: {
+                            msgid: "greeting",
+                            msgstr: ["Hello, world!"],
+                            comments: {
+                                extracted: "descriptor",
+                            },
+                        },
+                    },
+                    {
+                        error: undefined,
+                        translation: {
+                            msgid: "greeting",
+                            msgstr: ["Hello, world!"],
+                            comments: {
+                                extracted: "multiline\ncomment",
+                            },
+                        },
+                    },
                     {
                         error: undefined,
                         translation: {


### PR DESCRIPTION
## Summary
- combine msg query patterns using tree-sitter alternation
- adjust query index and tests

## Testing
- `npm test`
- `npm run check`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b5df9b89b4832f9a07096132ff4dbc