### PR TITLE
Refactor gettext queries and reuse msg logic

### DIFF
--- a/packages/extract/src/queries/gettext.ts
+++ b/packages/extract/src/queries/gettext.ts
@@ -1,5 +1,6 @@
 import { withComment } from "./comment.ts";
 import type { QuerySpec } from "./types.ts";
+import { extractMessage, msgArgs } from "./msg.ts";
 
 const gettextCall = (args: string) => `(
   (call_expression
@@ -12,77 +13,8 @@ const gettextCall = (args: string) => `(
   (#eq? @func "gettext")
 )`;
 
-export const gettextStringQuery: QuerySpec = withComment({
-    pattern: gettextCall(`(arguments
-    (string (string_fragment) @msgid)
-)`),
-    extract(match) {
-        const node = match.captures.find((c) => c.name === "call")?.node;
-        if (!node) {
-            return undefined;
-        }
-
-        const msgid = match.captures.find((c) => c.name === "msgid")?.node.text;
-        if (!msgid) {
-            return undefined;
-        }
-
-        return {
-            node,
-            translation: {
-                msgid,
-                msgstr: [msgid],
-            },
-        };
-    },
-});
-
-export const gettextDescriptorQuery: QuerySpec = withComment({
-    pattern: gettextCall(`(arguments
-        (object
-                (_)*
-                (pair
-                key: (property_identifier) @id_key
-                value: (string (string_fragment) @id)
-                (#eq? @id_key "id")
-                )?
-                (_)*
-                (pair
-                key: (property_identifier) @msg_key
-                value: (string (string_fragment) @message)
-                (#eq? @msg_key "message")
-                )?
-                (_)*
-        )
-)`),
-    extract(match) {
-        const node = match.captures.find((c) => c.name === "call")?.node;
-        if (!node) {
-            return undefined;
-        }
-
-        const id = match.captures.find((c) => c.name === "id")?.node.text;
-        const message = match.captures.find((c) => c.name === "message")?.node.text;
-        const msgid = id ?? message;
-        if (!msgid) {
-            return undefined;
-        }
-
-        const msgstr = message ?? id ?? "";
-
-        return {
-            node,
-            translation: {
-                msgid,
-                msgstr: [msgstr],
-            },
-        };
-    },
-});
-
-export const gettextTemplateQuery: QuerySpec = withComment({
-    pattern: gettextCall(`[
-        (template_string) @tpl
+export const gettextQuery: QuerySpec = withComment({
+    pattern: gettextCall(`[${msgArgs}
         (arguments (
             call_expression
                 function: (identifier) @msgfn
@@ -90,38 +22,7 @@ export const gettextTemplateQuery: QuerySpec = withComment({
                 (#eq? @msgfn "msg")
         ))
     ]`),
-    extract(match) {
-        const node = match.captures.find((c) => c.name === "call")?.node;
-        if (!node) {
-            return undefined;
-        }
-
-        const tpl = match.captures.find((c) => c.name === "tpl")?.node;
-        if (!tpl) {
-            return undefined;
-        }
-
-        for (const child of tpl.children) {
-            if (child.type !== "template_substitution") {
-                continue;
-            }
-
-            const expr = child.namedChildren[0];
-            if (!expr || expr.type !== "identifier") {
-                return {
-                    node,
-                    error: "gettext() template expressions must be simple identifiers",
-                };
-            }
-        }
-
-        const text = tpl.text.slice(1, -1);
-
-        return {
-            node,
-            translation: { msgid: text, msgstr: [text] },
-        };
-    },
+    extract: extractMessage("gettext"),
 });
 
 const allowed = new Set(["string", "object", "template_string", "identifier", "call_expression"]);

--- a/packages/extract/src/queries/index.ts
+++ b/packages/extract/src/queries/index.ts
@@ -1,4 +1,4 @@
-import { gettextDescriptorQuery, gettextInvalidQuery, gettextStringQuery, gettextTemplateQuery } from "./gettext.ts";
+import { gettextInvalidQuery, gettextQuery } from "./gettext.ts";
 import { msgInvalidQuery, msgQuery } from "./msg.ts";
 import type { QuerySpec } from "./types.ts";
 
@@ -7,8 +7,6 @@ export type { MessageMatch, QuerySpec } from "./types.ts";
 export const queries: QuerySpec[] = [
     msgQuery,
     msgInvalidQuery,
-    gettextStringQuery,
-    gettextDescriptorQuery,
-    gettextTemplateQuery,
+    gettextQuery,
     gettextInvalidQuery,
 ];

--- a/packages/extract/src/queries/msg.ts
+++ b/packages/extract/src/queries/msg.ts
@@ -1,5 +1,6 @@
 import { withComment } from "./comment.ts";
-import type { QuerySpec } from "./types.ts";
+import type { MessageMatch, QuerySpec } from "./types.ts";
+import type Parser from "tree-sitter";
 
 const msgCall = (args: string) => `(
   (call_expression
@@ -9,88 +10,92 @@ const msgCall = (args: string) => `(
   (#eq? @func "msg")
 )`;
 
-export const msgQuery: QuerySpec = withComment({
-    pattern: msgCall(`[
-        (arguments
-            [
-                (string (string_fragment) @msgid)
-                (object
-                        (_)* 
-                        (pair
-                        key: (property_identifier) @id_key
-                        value: (string (string_fragment) @id)
-                        (#eq? @id_key "id")
-                        )?
-                        (_)* 
-                        (pair
-                        key: (property_identifier) @msg_key
-                        value: (string (string_fragment) @message)
-                        (#eq? @msg_key "message")
-                        )?
-                        (_)* 
-                )
-            ]
-        )
-        (template_string) @tpl
-    ]`),
-    extract(match) {
-        const node = match.captures.find((c) => c.name === "call")?.node;
-        if (!node) {
-            return undefined;
-        }
+export const msgArgs = `
+    (arguments
+        [
+            (string (string_fragment) @msgid)
+            (object
+                    (_)*
+                    (pair
+                    key: (property_identifier) @id_key
+                    value: (string (string_fragment) @id)
+                    (#eq? @id_key "id")
+                    )?
+                    (_)*
+                    (pair
+                    key: (property_identifier) @msg_key
+                    value: (string (string_fragment) @message)
+                    (#eq? @msg_key "message")
+                    )?
+                    (_)*
+            )
+        ]
+    )
+    (template_string) @tpl
+`;
 
-        const msgid = match.captures.find((c) => c.name === "msgid")?.node.text;
-        if (msgid) {
-            return {
-                node,
-                translation: {
-                    msgid,
-                    msgstr: [msgid],
-                },
-            };
-        }
+export const extractMessage = (name: string) => (match: Parser.QueryMatch): MessageMatch | undefined => {
+    const node = match.captures.find((c) => c.name === "call")?.node;
+    if (!node) {
+        return undefined;
+    }
 
-        const tpl = match.captures.find((c) => c.name === "tpl")?.node;
-        if (tpl) {
-            for (const child of tpl.children) {
-                if (child.type !== "template_substitution") {
-                    continue;
-                }
-
-                const expr = child.namedChildren[0];
-                if (!expr || expr.type !== "identifier") {
-                    return {
-                        node,
-                        error: "msg() template expressions must be simple identifiers",
-                    };
-                }
-            }
-
-            const text = tpl.text.slice(1, -1);
-
-            return {
-                node,
-                translation: { msgid: text, msgstr: [text] },
-            };
-        }
-
-        const id = match.captures.find((c) => c.name === "id")?.node.text;
-        const message = match.captures.find((c) => c.name === "message")?.node.text;
-        const msgId = id ?? message;
-        if (!msgId) {
-            return undefined;
-        }
-
-        const msgstr = message ?? id ?? "";
-
+    const msgid = match.captures.find((c) => c.name === "msgid")?.node.text;
+    if (msgid) {
         return {
             node,
             translation: {
-                msgid: msgId,
-                msgstr: [msgstr],
+                msgid,
+                msgstr: [msgid],
             },
         };
-    },
+    }
+
+    const tpl = match.captures.find((c) => c.name === "tpl")?.node;
+    if (tpl) {
+        for (const child of tpl.children) {
+            if (child.type !== "template_substitution") {
+                continue;
+            }
+
+            const expr = child.namedChildren[0];
+            if (!expr || expr.type !== "identifier") {
+                return {
+                    node,
+                    error: `${name}() template expressions must be simple identifiers`,
+                };
+            }
+        }
+
+        const text = tpl.text.slice(1, -1);
+
+        return {
+            node,
+            translation: { msgid: text, msgstr: [text] },
+        };
+    }
+
+    const id = match.captures.find((c) => c.name === "id")?.node.text;
+    const message = match.captures.find((c) => c.name === "message")?.node.text;
+    const msgId = id ?? message;
+    if (!msgId) {
+        return undefined;
+    }
+
+    const msgstr = message ?? id ?? "";
+
+    return {
+        node,
+        translation: {
+            msgid: msgId,
+            msgstr: [msgstr],
+        },
+    };
+};
+
+export const msgQuery: QuerySpec = withComment({
+    pattern: msgCall(`[${msgArgs}]`),
+    extract: extractMessage("msg"),
 });
 
 const allowed = new Set(["string", "object", "template_string"]);

--- a/packages/extract/src/queries/tests/gettext.test.ts
+++ b/packages/extract/src/queries/tests/gettext.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { suite, test } from "node:test";
-import { gettextDescriptorQuery, gettextInvalidQuery, gettextStringQuery, gettextTemplateQuery } from "../gettext.ts";
+import { gettextInvalidQuery, gettextQuery } from "../gettext.ts";
 import { msgQuery } from "../msg.ts";
 import { getMatches } from "./utils.ts";
 
@@ -9,71 +9,51 @@ const fixture = readFileSync(new URL("./fixtures/gettext.ts", import.meta.url)).
 
 const paths = ["test.js", "test.jsx", "test.ts", "test.tsx"];
 
-suite("should extract string message", () =>
+suite("should extract messages", () =>
     paths.forEach((path) => {
         test(path, () => {
-            const matches = getMatches(fixture, path, gettextStringQuery);
-            const translations = matches.map(({ translation }) => translation);
+            const matches = getMatches(fixture, path, gettextQuery);
 
-            assert.equal(translations.length, 2);
-            assert.deepEqual(translations, [
-                {
-                    msgid: "hello",
-                    msgstr: ["hello"],
-                },
-                {
-                    msgid: "hello comment",
-                    msgstr: ["hello comment"],
-                    comments: {
-                        extracted: "comment",
-                    },
-                },
-            ]);
-        });
-    }),
-);
-
-suite("should extract descriptor message", () =>
-    paths.forEach((path) => {
-        test(path, () => {
-            const matches = getMatches(fixture, path, gettextDescriptorQuery);
-
-            assert.equal(matches.length, 2);
             assert.deepEqual(
-                matches.map(({ translation }) => translation),
+                matches.map(({ translation, error }) => ({ translation, error })),
                 [
                     {
-                        msgid: "greeting",
-                        msgstr: ["Hello, world!"],
-                        comments: {
-                            extracted: "descriptor",
+                        error: undefined,
+                        translation: {
+                            msgid: "hello",
+                            msgstr: ["hello"],
                         },
                     },
                     {
-                        msgid: "greeting",
-                        msgstr: ["Hello, world!"],
-                        comments: {
-                            extracted: "multiline\ncomment",
+                        error: undefined,
+                        translation: {
+                            msgid: "hello comment",
+                            msgstr: ["hello comment"],
+                            comments: {
+                                extracted: "comment",
+                            },
                         },
                     },
-                ],
-            );
-        });
-    }),
-);
-
-suite("should extract template message", () =>
-    paths.forEach((path) => {
-        test(path, () => {
-            const matches = getMatches(fixture, path, gettextTemplateQuery);
-
-            assert.equal(matches.length, 3);
-            assert.deepEqual(
-                matches.map(({ translation, error }) => ({
-                    error,
-                    translation,
-                })),
-                [
+                    {
+                        error: undefined,
+                        translation: {
+                            msgid: "greeting",
+                            msgstr: ["Hello, world!"],
+                            comments: {
+                                extracted: "descriptor",
+                            },
+                        },
+                    },
+                    {
+                        error: undefined,
+                        translation: {
+                            msgid: "greeting",
+                            msgstr: ["Hello, world!"],
+                            comments: {
+                                extracted: "multiline\ncomment",
+                            },
+                        },
+                    },
                     {
                         error: undefined,
                         translation: {
@@ -121,7 +101,7 @@ suite("should handle combined usage with msg", () =>
         test(path, () => {
             const source = `import { msg } from "@let-value/translate";\nconst t = { gettext: (v) => v };\nconst name = "World";\nt.gettext(msg\`Hello, \${name}!\`);`;
             const msgMatches = getMatches(source, path, msgQuery);
-            const gettextMatches = getMatches(source, path, gettextTemplateQuery);
+            const gettextMatches = getMatches(source, path, gettextQuery);
             const invalidMatches = getMatches(source, path, gettextInvalidQuery);
             assert.equal(msgMatches.length, 0);
             assert.equal(gettextMatches.length, 1);
@@ -129,3 +109,4 @@ suite("should handle combined usage with msg", () =>
         });
     }),
 );
+


### PR DESCRIPTION
## Summary
- consolidate gettext string, descriptor and template queries into one
- share message extraction logic and argument patterns with msg query
- update tests for unified gettext query

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b5e2bced20832f9a9021adb3a134da