### PR TITLE
feat: extract plural messages

### DIFF
--- a/packages/extract/src/queries/index.ts
+++ b/packages/extract/src/queries/index.ts
@@ -1,5 +1,6 @@
 import { gettextInvalidQuery, gettextQuery } from "./gettext.ts";
 import { msgInvalidQuery, msgQuery } from "./msg.ts";
+import { pluralQuery } from "./plural.ts";
 import type { QuerySpec } from "./types.ts";
 
 export type { MessageMatch, QuerySpec } from "./types.ts";
@@ -9,4 +10,5 @@ export const queries: QuerySpec[] = [
     msgInvalidQuery,
     gettextQuery,
     gettextInvalidQuery,
+    pluralQuery,
 ];

--- a/packages/extract/src/queries/msg.ts
+++ b/packages/extract/src/queries/msg.ts
@@ -95,7 +95,22 @@ export const extractMessage = (name: string) => (match: Parser.QueryMatch): Mess
 
 export const msgQuery: QuerySpec = withComment({
     pattern: msgCall(`[${msgArgs}]`),
-    extract: extractMessage("msg"),
+    extract(match) {
+        const node = match.captures.find((c) => c.name === "call")?.node;
+        if (!node) {
+            return undefined;
+        }
+
+        const parentCall = node.parent?.parent;
+        if (parentCall?.type === "call_expression") {
+            const func = parentCall.childForFieldName("function");
+            if (func?.text === "plural") {
+                return undefined;
+            }
+        }
+
+        return extractMessage("msg")(match);
+    },
 });
 
 const allowed = new Set(["string", "object", "template_string"]);

--- a/packages/extract/src/queries/plural.ts
+++ b/packages/extract/src/queries/plural.ts
@@ -1,0 +1,80 @@
+import { withComment } from "./comment.ts";
+import { extractMessage, msgArgs } from "./msg.ts";
+import type { QuerySpec } from "./types.ts";
+import type Parser from "tree-sitter";
+
+const pluralCall = (args: string) => `(
+  (call_expression
+    function: (identifier) @func
+    arguments: (arguments ${args})
+  ) @call
+  (#eq? @func "plural")
+)`;
+
+function isDescendant(node: Parser.SyntaxNode, ancestor: Parser.SyntaxNode): boolean {
+    let current: Parser.SyntaxNode | null = node;
+    while (current) {
+        if (current.id === ancestor.id) return true;
+        current = current.parent;
+    }
+    return false;
+}
+
+export const pluralQuery: QuerySpec = withComment({
+    pattern: pluralCall(`
+            (
+                (call_expression
+                    function: (identifier) @msgfn
+                    arguments: [${msgArgs}]
+                    (#eq? @msgfn "msg")
+                ) @msg
+                ("," )?
+            )+
+            (number) @n
+        `),
+    extract(match) {
+        const call = match.captures.find((c) => c.name === "call")?.node;
+        if (!call) {
+            return undefined;
+        }
+
+        const msgNodes = match.captures.filter((c) => c.name === "msg").map((c) => c.node);
+
+        const ids: string[] = [];
+        const strs: string[] = [];
+
+        for (const node of msgNodes) {
+            const relevant = match.captures.filter((c) =>
+                ["msgid", "id", "message", "tpl"].includes(c.name) && isDescendant(c.node, node)
+            );
+
+            const subMatch: Parser.QueryMatch = {
+                pattern: 0,
+                captures: [{ name: "call", node }, ...relevant],
+            };
+
+            const result = extractMessage("plural")(subMatch);
+            if (!result) continue;
+            if (result.error) {
+                return { node: call, error: result.error };
+            }
+            if (result.translation) {
+                ids.push(result.translation.msgid);
+                strs.push(result.translation.msgstr[0] ?? "");
+            }
+        }
+
+        if (ids.length === 0) {
+            return undefined;
+        }
+
+        const translation = {
+            msgid: ids[0],
+            msgid_plural: ids[1],
+            msgstr: strs,
+        };
+
+        return { node: call, translation };
+    },
+});
+

--- a/packages/extract/src/queries/tests/fixtures/plural.ts
+++ b/packages/extract/src/queries/tests/fixtures/plural.ts
@@ -1,0 +1,14 @@
+import { msg, plural } from "@let-value/translate";
+
+plural(msg("hello"), msg("hellos"), 1);
+
+const count = 0;
+// comment
+plural(msg`${count} apple`, msg`${count} apples`, 2);
+
+plural(msg({ id: "greeting", message: "Hello, world!" }), msg({ id: "greetings", message: "Hello, worlds!" }), 3);
+
+const name = "World";
+plural(msg`Hello, ${name}!`, msg`Hello, ${name}!`, 1);
+
+plural(msg`Hi, ${name.toUpperCase()}!`, msg`Hi, ${name}!`, 1);

--- a/packages/extract/src/queries/tests/plural.test.ts
+++ b/packages/extract/src/queries/tests/plural.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { suite, test } from "node:test";
+import { pluralQuery } from "../plural.ts";
+import { msgQuery } from "../msg.ts";
+import { getMatches } from "./utils.ts";
+
+const fixture = readFileSync(new URL("./fixtures/plural.ts", import.meta.url)).toString();
+
+const paths = ["test.js", "test.jsx", "test.ts", "test.tsx"];
+
+suite("should extract plural messages", () =>
+    paths.forEach((path) => {
+        test(path, () => {
+            const matches = getMatches(fixture, path, pluralQuery);
+
+            assert.deepEqual(
+                matches.map(({ translation, error }) => ({ translation, error })),
+                [
+                    {
+                        error: undefined,
+                        translation: {
+                            msgid: "hello",
+                            msgid_plural: "hellos",
+                            msgstr: ["hello", "hellos"],
+                        },
+                    },
+                    {
+                        error: undefined,
+                        translation: {
+                            msgid: "${count} apple",
+                            msgid_plural: "${count} apples",
+                            msgstr: ["${count} apple", "${count} apples"],
+                            comments: {
+                                extracted: "comment",
+                            },
+                        },
+                    },
+                    {
+                        error: undefined,
+                        translation: {
+                            msgid: "greeting",
+                            msgid_plural: "greetings",
+                            msgstr: ["Hello, world!", "Hello, worlds!"],
+                        },
+                    },
+                    {
+                        error: undefined,
+                        translation: {
+                            msgid: "Hello, ${name}!",
+                            msgid_plural: "Hello, ${name}!",
+                            msgstr: ["Hello, ${name}!", "Hello, ${name}!"],
+                        },
+                    },
+                    {
+                        error: "plural() template expressions must be simple identifiers",
+                        translation: undefined,
+                    },
+                ],
+            );
+        });
+    }),
+);
+
+suite("msg query should ignore plural arguments", () =>
+    paths.forEach((path) => {
+        test(path, () => {
+            const matches = getMatches(fixture, path, msgQuery);
+            assert.equal(matches.length, 0);
+        });
+    }),
+);


### PR DESCRIPTION
## Summary
- ignore `msg` calls nested inside `plural`
- extract plural messages using new plural query
- add tests for plural extraction and ensure msg query ignores plural args

## Testing
- `npm test`
- `npm run check` *(fails: Cannot find module '@biomejs/cli-linux-x64/biome')*


------
https://chatgpt.com/codex/tasks/task_e_68b5e689c4dc832f9c13072b4ad6d832