### PR TITLE
feat: extract ngettext plural messages

### DIFF
--- a/extract/src/queries/index.ts
+++ b/extract/src/queries/index.ts
@@ -1,8 +1,16 @@
 import { gettextInvalidQuery, gettextQuery } from "./gettext.ts";
 import { msgInvalidQuery, msgQuery } from "./msg.ts";
 import { pluralQuery } from "./plural.ts";
+import { ngettextQuery } from "./ngettext.ts";
 import type { QuerySpec } from "./types.ts";
 
 export type { MessageMatch, QuerySpec } from "./types.ts";
 
-export const queries: QuerySpec[] = [msgQuery, msgInvalidQuery, gettextQuery, gettextInvalidQuery, pluralQuery];
+export const queries: QuerySpec[] = [
+    msgQuery,
+    msgInvalidQuery,
+    gettextQuery,
+    gettextInvalidQuery,
+    pluralQuery,
+    ngettextQuery,
+];

--- a/extract/src/queries/msg.ts
+++ b/extract/src/queries/msg.ts
@@ -27,13 +27,18 @@ const notInPlural = (query: QuerySpec): QuerySpec => ({
             parent = parent.parent;
         }
 
-        if (
-            parent &&
-            parent.type === "call_expression" &&
-            parent.childForFieldName("function")?.type === "identifier" &&
-            parent.childForFieldName("function")?.text === "plural"
-        ) {
-            return undefined;
+        if (parent && parent.type === "call_expression") {
+            const fn = parent.childForFieldName("function");
+            if (fn) {
+                if (
+                    (fn.type === "identifier" &&
+                        (fn.text === "plural" || fn.text === "ngettext")) ||
+                    (fn.type === "member_expression" &&
+                        fn.childForFieldName("property")?.text === "ngettext")
+                ) {
+                    return undefined;
+                }
+            }
         }
 
         return result;

--- a/extract/src/queries/ngettext.ts
+++ b/extract/src/queries/ngettext.ts
@@ -1,0 +1,86 @@
+import type Parser from "tree-sitter";
+import { withComment } from "./comment.ts";
+import { extractMessage, msgArgs } from "./msg.ts";
+import type { QuerySpec } from "./types.ts";
+
+const ngettextCall = (args: string) => `(
+  (call_expression
+    function: [
+      (identifier) @func
+      (member_expression property: (property_identifier) @func)
+    ]
+    arguments: (arguments ${args})
+  ) @call
+  (#eq? @func "ngettext")
+)`;
+
+function isDescendant(node: Parser.SyntaxNode, ancestor: Parser.SyntaxNode): boolean {
+    let current: Parser.SyntaxNode | null = node;
+    while (current) {
+        if (current.id === ancestor.id) return true;
+        current = current.parent;
+    }
+    return false;
+}
+
+export const ngettextQuery: QuerySpec = withComment({
+    pattern: ngettextCall(`
+            (
+                (call_expression
+                    function: [
+                        (identifier) @msgfn
+                        (member_expression property: (property_identifier) @msgfn)
+                    ]
+                    arguments: [${msgArgs}]
+                    (#eq? @msgfn "msg")
+                ) @msg
+                ("," )?
+            )+
+            (number) @n
+        `),
+    extract(match) {
+        const call = match.captures.find((c) => c.name === "call")?.node;
+        if (!call) {
+            return undefined;
+        }
+
+        const msgNodes = match.captures.filter((c) => c.name === "msg").map((c) => c.node);
+
+        const ids: string[] = [];
+        const strs: string[] = [];
+
+        for (const node of msgNodes) {
+            const relevant = match.captures.filter(
+                (c) => ["msgid", "id", "message", "tpl"].includes(c.name) && isDescendant(c.node, node),
+            );
+
+            const subMatch: Parser.QueryMatch = {
+                pattern: 0,
+                captures: [{ name: "call", node }, ...relevant],
+            };
+
+            const result = extractMessage("ngettext")(subMatch);
+            if (!result) continue;
+            if (result.error) {
+                return { node: call, error: result.error };
+            }
+            if (result.translation) {
+                ids.push(result.translation.msgid);
+                strs.push(result.translation.msgstr[0] ?? "");
+            }
+        }
+
+        if (ids.length === 0) {
+            return undefined;
+        }
+
+        const translation = {
+            msgid: ids[0],
+            msgid_plural: ids[1],
+            msgstr: strs,
+        };
+
+        return { node: call, translation };
+    },
+});
+

--- a/extract/src/queries/tests/fixtures/ngettext.ts
+++ b/extract/src/queries/tests/fixtures/ngettext.ts
@@ -1,0 +1,20 @@
+import { msg, Translator } from "@let-value/translate";
+
+const t = new Translator("en", {});
+
+t.ngettext(msg("hello"), msg("hellos"), 1);
+
+const count = 0;
+// comment
+t.ngettext(msg`${count} apple`, msg`${count} apples`, 2);
+
+t.ngettext(
+    msg({ id: "greeting", message: "Hello, world!" }),
+    msg({ id: "greetings", message: "Hello, worlds!" }),
+    3,
+);
+
+const name = "World";
+t.ngettext(msg`Hello, ${name}!`, msg`Hello, ${name}!`, 1);
+
+t.ngettext(msg`Hi, ${name.toUpperCase()}!`, msg`Hi, ${name}!`, 1);

--- a/extract/src/queries/tests/ngettext.test.ts
+++ b/extract/src/queries/tests/ngettext.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { suite, test } from "node:test";
+import { msgQuery } from "../msg.ts";
+import { ngettextQuery } from "../ngettext.ts";
+import { getMatches } from "./utils.ts";
+
+const fixture = readFileSync(new URL("./fixtures/ngettext.ts", import.meta.url)).toString();
+
+const paths = ["test.js", "test.jsx", "test.ts", "test.tsx"];
+
+suite("should extract plural messages", () =>
+    paths.forEach((path) => {
+        test(path, () => {
+            const matches = getMatches(fixture, path, ngettextQuery);
+
+            assert.deepEqual(
+                matches.map(({ translation, error }) => ({ translation, error })),
+                [
+                    {
+                        error: undefined,
+                        translation: {
+                            msgid: "hello",
+                            msgid_plural: "hellos",
+                            msgstr: ["hello", "hellos"],
+                        },
+                    },
+                    {
+                        error: undefined,
+                        translation: {
+                            msgid: "${count} apple",
+                            msgid_plural: "${count} apples",
+                            msgstr: ["${count} apple", "${count} apples"],
+                            comments: {
+                                extracted: "comment",
+                            },
+                        },
+                    },
+                    {
+                        error: undefined,
+                        translation: {
+                            msgid: "greeting",
+                            msgid_plural: "greetings",
+                            msgstr: ["Hello, world!", "Hello, worlds!"],
+                        },
+                    },
+                    {
+                        error: undefined,
+                        translation: {
+                            msgid: "Hello, ${name}!",
+                            msgid_plural: "Hello, ${name}!",
+                            msgstr: ["Hello, ${name}!", "Hello, ${name}!"]
+                        },
+                    },
+                    {
+                        error: "ngettext() template expressions must be simple identifiers",
+                        translation: undefined,
+                    },
+                ],
+            );
+        });
+    }),
+);
+
+suite("msg query should ignore ngettext arguments", () =>
+    paths.forEach((path) => {
+        test(path, () => {
+            const matches = getMatches(fixture, path, msgQuery);
+            assert.equal(matches.length, 0);
+        });
+    }),
+);


### PR DESCRIPTION
## Summary
- support extracting plural translations from `ngettext` calls
- skip `msg` extractions when used inside `ngettext`
- add tests for `ngettext` extraction

## Testing
- `npm --workspace extract test`
- `npm --workspace translate test`
- `npm run typecheck`
- `npm run check` *(fails: Cannot find module '@biomejs/cli-linux-x64/biome')*


------
https://chatgpt.com/codex/tasks/task_e_68b697f0ce48832fbff07184c490f26e