### PR TITLE
feat: support context-aware extraction

### DIFF
--- a/extract/src/queries/index.ts
+++ b/extract/src/queries/index.ts
@@ -2,6 +2,8 @@ import { gettextInvalidQuery, gettextQuery } from "./gettext.ts";
 import { msgInvalidQuery, msgQuery } from "./msg.ts";
 import { pluralQuery } from "./plural.ts";
 import { ngettextQuery } from "./ngettext.ts";
+import { pgettextQuery } from "./pgettext.ts";
+import { npgettextQuery } from "./npgettext.ts";
 import type { QuerySpec } from "./types.ts";
 
 export type { MessageMatch, QuerySpec } from "./types.ts";
@@ -13,4 +15,6 @@ export const queries: QuerySpec[] = [
     gettextInvalidQuery,
     pluralQuery,
     ngettextQuery,
+    pgettextQuery,
+    npgettextQuery,
 ];

--- a/extract/src/queries/msg.ts
+++ b/extract/src/queries/msg.ts
@@ -32,9 +32,14 @@ const notInPlural = (query: QuerySpec): QuerySpec => ({
             if (fn) {
                 if (
                     (fn.type === "identifier" &&
-                        (fn.text === "plural" || fn.text === "ngettext")) ||
+                        (fn.text === "plural" ||
+                            fn.text === "ngettext" ||
+                            fn.text === "pgettext" ||
+                            fn.text === "npgettext")) ||
                     (fn.type === "member_expression" &&
-                        fn.childForFieldName("property")?.text === "ngettext")
+                        ["ngettext", "pgettext", "npgettext"].includes(
+                            fn.childForFieldName("property")?.text ?? "",
+                        ))
                 ) {
                     return undefined;
                 }

--- a/extract/src/queries/npgettext.ts
+++ b/extract/src/queries/npgettext.ts
@@ -1,0 +1,91 @@
+import type Parser from "tree-sitter";
+import { withComment } from "./comment.ts";
+import { extractMessage, msgArgs } from "./msg.ts";
+import type { QuerySpec } from "./types.ts";
+
+const npgettextCall = (args: string) => `(
+  (call_expression
+    function: [
+      (identifier) @func
+      (member_expression property: (property_identifier) @func)
+    ]
+    arguments: (arguments
+        (string (string_fragment) @msgctxt)
+        ","
+        ${args}
+    )
+  ) @call
+  (#eq? @func "npgettext")
+)`;
+
+function isDescendant(node: Parser.SyntaxNode, ancestor: Parser.SyntaxNode): boolean {
+    let current: Parser.SyntaxNode | null = node;
+    while (current) {
+        if (current.id === ancestor.id) return true;
+        current = current.parent;
+    }
+    return false;
+}
+
+export const npgettextQuery: QuerySpec = withComment({
+    pattern: npgettextCall(`
+            (
+                (call_expression
+                    function: [
+                        (identifier) @msgfn
+                        (member_expression property: (property_identifier) @msgfn)
+                    ]
+                    arguments: [${msgArgs}]
+                    (#eq? @msgfn "msg")
+                ) @msg
+                ("," )?
+            )+
+            (number) @n
+        `),
+    extract(match) {
+        const call = match.captures.find((c) => c.name === "call")?.node;
+        if (!call) {
+            return undefined;
+        }
+
+        const msgctxt = match.captures.find((c) => c.name === "msgctxt")?.node?.text;
+        const msgNodes = match.captures.filter((c) => c.name === "msg").map((c) => c.node);
+
+        const ids: string[] = [];
+        const strs: string[] = [];
+
+        for (const node of msgNodes) {
+            const relevant = match.captures.filter(
+                (c) => ["msgid", "id", "message", "tpl"].includes(c.name) && isDescendant(c.node, node),
+            );
+
+            const subMatch: Parser.QueryMatch = {
+                pattern: 0,
+                captures: [{ name: "call", node }, ...relevant],
+            };
+
+            const result = extractMessage("npgettext")(subMatch);
+            if (!result) continue;
+            if (result.error) {
+                return { node: call, error: result.error };
+            }
+            if (result.translation) {
+                ids.push(result.translation.msgid);
+                strs.push(result.translation.msgstr[0] ?? "");
+            }
+        }
+
+        if (ids.length === 0) {
+            return undefined;
+        }
+
+        const translation = {
+            msgid: ids[0],
+            msgid_plural: ids[1],
+            msgstr: strs,
+            msgctxt,
+        };
+
+        return { node: call, translation };
+    },
+});

--- a/extract/src/queries/pgettext.ts
+++ b/extract/src/queries/pgettext.ts
@@ -1,0 +1,56 @@
+import { withComment } from "./comment.ts";
+import { extractMessage } from "./msg.ts";
+import type { QuerySpec } from "./types.ts";
+
+const msgArg = `[
+    (string (string_fragment) @msgid)
+    (object
+            (_)*
+            (pair
+                key: (property_identifier) @id_key
+                value: (string (string_fragment) @id)
+                (#eq? @id_key "id")
+            )?
+            (_)*
+            (pair
+                key: (property_identifier) @msg_key
+                value: (string (string_fragment) @message)
+                (#eq? @msg_key "message")
+            )?
+            (_)*
+    )
+    (template_string) @tpl
+]`;
+
+const pgettextCall = (arg: string) => `(
+  (call_expression
+    function: [
+      (identifier) @func
+      (member_expression property: (property_identifier) @func)
+    ]
+    arguments: (arguments
+        (string (string_fragment) @msgctxt)
+        ","
+        ${arg}
+    )
+  ) @call
+  (#eq? @func "pgettext")
+)`;
+
+export const pgettextQuery: QuerySpec = withComment({
+    pattern: pgettextCall(msgArg),
+    extract(match) {
+        const result = extractMessage("pgettext")(match);
+        const contextNode = match.captures.find((c) => c.name === "msgctxt")?.node;
+        if (!result || !contextNode || !result.translation) {
+            return result;
+        }
+        return {
+            node: result.node,
+            translation: {
+                ...result.translation,
+                msgctxt: contextNode.text,
+            },
+        };
+    },
+});

--- a/extract/src/queries/tests/fixtures/npgettext.ts
+++ b/extract/src/queries/tests/fixtures/npgettext.ts
@@ -1,0 +1,21 @@
+import { msg, Translator } from "@let-value/translate";
+
+const t = new Translator("en", {});
+
+t.npgettext("ctx", msg("hello"), msg("hellos"), 1);
+
+const count = 0;
+// comment
+t.npgettext("company", msg`${count} apple`, msg`${count} apples`, 2);
+
+t.npgettext(
+    "ctx",
+    msg({ id: "greeting", message: "Hello, world!" }),
+    msg({ id: "greetings", message: "Hello, worlds!" }),
+    3,
+);
+
+const name = "World";
+t.npgettext("ctx", msg`Hello, ${name}!`, msg`Hello, ${name}!`, 1);
+
+t.npgettext("ctx", msg`Hi, ${name.toUpperCase()}!`, msg`Hi, ${name}!`, 1);

--- a/extract/src/queries/tests/fixtures/pgettext.ts
+++ b/extract/src/queries/tests/fixtures/pgettext.ts
@@ -1,0 +1,30 @@
+import { Translator } from "@let-value/translate";
+
+const t = new Translator("en", {});
+
+t.pgettext("ctx", "hello");
+
+// comment
+t.pgettext("ctx", "hello comment");
+
+// descriptor
+t.pgettext("ctx", { id: "greeting", message: "Hello, world!" });
+
+/* multiline
+ * comment */
+t.pgettext("ctx", { id: "greeting", message: "Hello, world!" });
+
+const name = "World";
+t.pgettext("ctx", `Hello, ${name}!`);
+
+// @ts-expect-error invalid call
+// biome-ignore lint/style/useTemplate: true
+t.pgettext("ctx", "Hi, " + name);
+
+function getGreeting() {
+    return name;
+}
+
+t.pgettext("ctx", `Hi, ${getGreeting()}!`);
+
+t.pgettext("ctx", `Hi, ${name.length}!`);

--- a/extract/src/queries/tests/npgettext.test.ts
+++ b/extract/src/queries/tests/npgettext.test.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { suite, test } from "node:test";
+import { msgQuery } from "../msg.ts";
+import { npgettextQuery } from "../npgettext.ts";
+import { getMatches } from "./utils.ts";
+
+const fixture = readFileSync(new URL("./fixtures/npgettext.ts", import.meta.url)).toString();
+
+const paths = ["test.js", "test.jsx", "test.ts", "test.tsx"];
+
+suite("should extract context plural messages", () =>
+    paths.forEach((path) => {
+        test(path, () => {
+            const matches = getMatches(fixture, path, npgettextQuery);
+            assert.deepEqual(
+                matches.map(({ translation, error }) => ({ translation, error })),
+                [
+                    {
+                        error: undefined,
+                        translation: {
+                            msgctxt: "ctx",
+                            msgid: "hello",
+                            msgid_plural: "hellos",
+                            msgstr: ["hello", "hellos"],
+                        },
+                    },
+                    {
+                        error: undefined,
+                        translation: {
+                            msgctxt: "company",
+                            msgid: "${count} apple",
+                            msgid_plural: "${count} apples",
+                            msgstr: ["${count} apple", "${count} apples"],
+                            comments: {
+                                extracted: "comment",
+                            },
+                        },
+                    },
+                    {
+                        error: undefined,
+                        translation: {
+                            msgctxt: "ctx",
+                            msgid: "greeting",
+                            msgid_plural: "greetings",
+                            msgstr: ["Hello, world!", "Hello, worlds!"],
+                        },
+                    },
+                    {
+                        error: undefined,
+                        translation: {
+                            msgctxt: "ctx",
+                            msgid: "Hello, ${name}!",
+                            msgid_plural: "Hello, ${name}!",
+                            msgstr: ["Hello, ${name}!", "Hello, ${name}!"]
+                        },
+                    },
+                    {
+                        error: "npgettext() template expressions must be simple identifiers",
+                        translation: undefined,
+                    },
+                ],
+            );
+        });
+    }),
+);
+
+suite("msg query should ignore npgettext arguments", () =>
+    paths.forEach((path) => {
+        test(path, () => {
+            const matches = getMatches(fixture, path, msgQuery);
+            assert.equal(matches.length, 0);
+        });
+    }),
+);

--- a/extract/src/queries/tests/pgettext.test.ts
+++ b/extract/src/queries/tests/pgettext.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { suite, test } from "node:test";
+import { pgettextQuery } from "../pgettext.ts";
+import { getMatches } from "./utils.ts";
+
+const fixture = readFileSync(new URL("./fixtures/pgettext.ts", import.meta.url)).toString();
+
+const paths = ["test.js", "test.jsx", "test.ts", "test.tsx"];
+
+suite("should extract context messages", () =>
+    paths.forEach((path) => {
+        test(path, () => {
+            const matches = getMatches(fixture, path, pgettextQuery);
+            assert.deepEqual(
+                matches.map(({ translation, error }) => ({ translation, error })),
+                [
+                    {
+                        error: undefined,
+                        translation: {
+                            msgctxt: "ctx",
+                            msgid: "hello",
+                            msgstr: ["hello"],
+                        },
+                    },
+                    {
+                        error: undefined,
+                        translation: {
+                            msgctxt: "ctx",
+                            msgid: "hello comment",
+                            msgstr: ["hello comment"],
+                            comments: {
+                                extracted: "comment",
+                            },
+                        },
+                    },
+                    {
+                        error: undefined,
+                        translation: {
+                            msgctxt: "ctx",
+                            msgid: "greeting",
+                            msgstr: ["Hello, world!"],
+                            comments: {
+                                extracted: "descriptor",
+                            },
+                        },
+                    },
+                    {
+                        error: undefined,
+                        translation: {
+                            msgctxt: "ctx",
+                            msgid: "greeting",
+                            msgstr: ["Hello, world!"],
+                            comments: {
+                                extracted: "multiline\ncomment",
+                            },
+                        },
+                    },
+                    {
+                        error: undefined,
+                        translation: {
+                            msgctxt: "ctx",
+                            msgid: "Hello, ${name}!",
+                            msgstr: ["Hello, ${name}!"],
+                        },
+                    },
+                    {
+                        error: "pgettext() template expressions must be simple identifiers",
+                        translation: undefined,
+                    },
+                    {
+                        error: "pgettext() template expressions must be simple identifiers",
+                        translation: undefined,
+                    },
+                ],
+            );
+        });
+    }),
+);


### PR DESCRIPTION
## Summary
- add pgettext and npgettext queries for context-aware message extraction
- ensure msg query skips contextual calls
- cover new extraction paths with tests

## Testing
- `npm test`
- `npm run check` *(fails: Cannot find module '@biomejs/cli-linux-x64/biome')*


------
https://chatgpt.com/codex/tasks/task_e_68b6a6df10f0832f9a379cfa12028775