### PR TITLE
feat: support context builder extraction

### DIFF
--- a/extract/src/queries/context.ts
+++ b/extract/src/queries/context.ts
@@ -1,0 +1,61 @@
+import { withComment } from "./comment.ts";
+import { extractMessage, msgArgs } from "./msg.ts";
+import { extractPluralForms } from "./plural-utils.ts";
+import { callPattern } from "./utils.ts";
+import type { QuerySpec } from "./types.ts";
+
+const ctxCall = callPattern(
+    "context",
+    `(arguments (string (string_fragment) @msgctxt))`,
+)
+    .replace(/@call/g, "@ctx")
+    .replace(/@func/g, "@ctxfn");
+
+export const contextMsgQuery: QuerySpec = withComment({
+    pattern: `(
+  (call_expression
+    function: (member_expression
+      object: ${ctxCall}
+      property: (property_identifier) @func
+    )
+    arguments: ${msgArgs}
+  ) @call
+  (#eq? @func "msg")
+)` ,
+    extract(match) {
+        const result = extractMessage("context.msg")(match);
+        const contextNode = match.captures.find((c) => c.name === "msgctxt")?.node;
+        if (!result || !result.translation || !contextNode) {
+            return result;
+        }
+        return {
+            node: result.node,
+            translation: {
+                ...result.translation,
+                msgctxt: contextNode.text,
+            },
+        };
+    },
+});
+
+const msgCall = callPattern("msg", msgArgs, false)
+    .replace(/@call/g, "@msg")
+    .replace(/@func/g, "@msgfn");
+
+export const contextPluralQuery: QuerySpec = withComment({
+    pattern: `(
+  (call_expression
+    function: (member_expression
+      object: ${ctxCall}
+      property: (property_identifier) @func
+    )
+    arguments: (arguments (
+      (${msgCall} ("," )?)+
+      (number) @n
+    ))
+  ) @call
+  (#eq? @func "plural")
+)` ,
+    extract: extractPluralForms("context.plural"),
+});
+

--- a/extract/src/queries/index.ts
+++ b/extract/src/queries/index.ts
@@ -2,6 +2,7 @@ import { gettextInvalidQuery, gettextQuery } from "./gettext.ts";
 import { msgInvalidQuery, msgQuery } from "./msg.ts";
 import { ngettextQuery } from "./ngettext.ts";
 import { npgettextQuery } from "./npgettext.ts";
+import { contextMsgQuery, contextPluralQuery } from "./context.ts";
 import { pgettextQuery } from "./pgettext.ts";
 import { pluralQuery } from "./plural.ts";
 import type { QuerySpec } from "./types.ts";
@@ -17,4 +18,6 @@ export const queries: QuerySpec[] = [
     ngettextQuery,
     pgettextQuery,
     npgettextQuery,
+    contextMsgQuery,
+    contextPluralQuery,
 ];

--- a/extract/src/queries/msg.ts
+++ b/extract/src/queries/msg.ts
@@ -27,7 +27,9 @@ const notInPlural = (query: QuerySpec): QuerySpec => ({
                             fn.text === "pgettext" ||
                             fn.text === "npgettext")) ||
                     (fn.type === "member_expression" &&
-                        ["ngettext", "pgettext", "npgettext"].includes(fn.childForFieldName("property")?.text ?? ""))
+                        ["plural", "ngettext", "pgettext", "npgettext"].includes(
+                            fn.childForFieldName("property")?.text ?? "",
+                        ))
                 ) {
                     return undefined;
                 }

--- a/extract/src/queries/tests/context-plural.test.ts
+++ b/extract/src/queries/tests/context-plural.test.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { suite, test } from "node:test";
+import { contextPluralQuery } from "../context.ts";
+import { msgQuery } from "../msg.ts";
+import { getMatches } from "./utils.ts";
+
+const fixture = readFileSync(new URL("./fixtures/context-plural.ts", import.meta.url)).toString();
+
+const paths = ["test.js", "test.jsx", "test.ts", "test.tsx"];
+
+suite("should extract context builder plural messages", () =>
+    paths.forEach((path) => {
+        test(path, () => {
+            const matches = getMatches(fixture, path, contextPluralQuery);
+            assert.deepEqual(
+                matches.map(({ translation, error }) => ({ translation, error })),
+                [
+                    {
+                        error: undefined,
+                        translation: {
+                            msgctxt: "ctx",
+                            msgid: "hello",
+                            msgid_plural: "hellos",
+                            msgstr: ["hello", "hellos"],
+                        },
+                    },
+                    {
+                        error: undefined,
+                        translation: {
+                            msgctxt: "company",
+                            msgid: "${count} apple",
+                            msgid_plural: "${count} apples",
+                            msgstr: ["${count} apple", "${count} apples"],
+                            comments: {
+                                extracted: "comment",
+                            },
+                        },
+                    },
+                    {
+                        error: undefined,
+                        translation: {
+                            msgctxt: "ctx",
+                            msgid: "greeting",
+                            msgid_plural: "greetings",
+                            msgstr: ["Hello, world!", "Hello, worlds!"],
+                        },
+                    },
+                    {
+                        error: undefined,
+                        translation: {
+                            msgctxt: "ctx",
+                            msgid: "Hello, ${name}!",
+                            msgid_plural: "Hello, ${name}!",
+                            msgstr: ["Hello, ${name}!", "Hello, ${name}!"]
+                        },
+                    },
+                    {
+                        error: "context.plural() template expressions must be simple identifiers",
+                        translation: undefined,
+                    },
+                ],
+            );
+        });
+    }),
+);
+
+suite("msg query should ignore context plural arguments", () =>
+    paths.forEach((path) => {
+        test(path, () => {
+            const matches = getMatches(fixture, path, msgQuery);
+            assert.equal(matches.length, 0);
+        });
+    }),
+);

--- a/extract/src/queries/tests/context.test.ts
+++ b/extract/src/queries/tests/context.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { suite, test } from "node:test";
+import { contextMsgQuery } from "../context.ts";
+import { getMatches } from "./utils.ts";
+
+const fixture = readFileSync(new URL("./fixtures/context.ts", import.meta.url)).toString();
+
+const paths = ["test.js", "test.jsx", "test.ts", "test.tsx"];
+
+suite("should extract context builder messages", () =>
+    paths.forEach((path) => {
+        test(path, () => {
+            const matches = getMatches(fixture, path, contextMsgQuery);
+            assert.deepEqual(
+                matches.map(({ translation, error }) => ({ translation, error })),
+                [
+                    {
+                        error: undefined,
+                        translation: {
+                            msgctxt: "ctx",
+                            msgid: "hello",
+                            msgstr: ["hello"],
+                        },
+                    },
+                    {
+                        error: undefined,
+                        translation: {
+                            msgctxt: "ctx",
+                            msgid: "hello comment",
+                            msgstr: ["hello comment"],
+                            comments: {
+                                extracted: "comment",
+                            },
+                        },
+                    },
+                    {
+                        error: undefined,
+                        translation: {
+                            msgctxt: "ctx",
+                            msgid: "greeting",
+                            msgstr: ["Hello, world!"],
+                            comments: {
+                                extracted: "descriptor",
+                            },
+                        },
+                    },
+                    {
+                        error: undefined,
+                        translation: {
+                            msgctxt: "ctx",
+                            msgid: "greeting",
+                            msgstr: ["Hello, world!"],
+                            comments: {
+                                extracted: "multiline\ncomment",
+                            },
+                        },
+                    },
+                    {
+                        error: undefined,
+                        translation: {
+                            msgctxt: "ctx",
+                            msgid: "Hello, ${name}!",
+                            msgstr: ["Hello, ${name}!"]
+                        }
+                    },
+                    {
+                        error: "context.msg() template expressions must be simple identifiers",
+                        translation: undefined,
+                    },
+                    {
+                        error: "context.msg() template expressions must be simple identifiers",
+                        translation: undefined,
+                    },
+                ],
+            );
+        });
+    }),
+);

--- a/extract/src/queries/tests/fixtures/context-plural.ts
+++ b/extract/src/queries/tests/fixtures/context-plural.ts
@@ -1,0 +1,18 @@
+import { context, msg } from "@let-value/translate";
+
+context("ctx").plural(msg("hello"), msg("hellos"), 1);
+
+const count = 0;
+// comment
+context("company").plural(msg`${count} apple`, msg`${count} apples`, 2);
+
+context("ctx").plural(
+    msg({ id: "greeting", message: "Hello, world!" }),
+    msg({ id: "greetings", message: "Hello, worlds!" }),
+    3,
+);
+
+const name = "World";
+context("ctx").plural(msg`Hello, ${name}!`, msg`Hello, ${name}!`, 1);
+
+context("ctx").plural(msg`Hi, ${name.toUpperCase()}!`, msg`Hi, ${name}!`, 1);

--- a/extract/src/queries/tests/fixtures/context.ts
+++ b/extract/src/queries/tests/fixtures/context.ts
@@ -1,0 +1,19 @@
+import { context } from "@let-value/translate";
+
+context("ctx").msg("hello");
+
+// comment
+context("ctx").msg("hello comment");
+
+// descriptor
+context("ctx").msg({ id: "greeting", message: "Hello, world!" });
+
+/* multiline
+ * comment */
+context("ctx").msg({ id: "greeting", message: "Hello, world!" });
+
+const name = "World";
+context("ctx").msg`Hello, ${name}!`;
+
+context("ctx").msg`Hi, ${name.toUpperCase()}!`;
+context("ctx").msg`Hi, ${name.length}!`;


### PR DESCRIPTION
## Summary
- add queries to extract messages from `context().msg` and `context().plural`
- skip `msg` results when nested under `.plural`
- cover context builder queries with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6ca61ef50832fa806a124fd1bb2fc