### PR TITLE
feat(extract): add import query

### DIFF
--- a/extract/src/parse.ts
+++ b/extract/src/parse.ts
@@ -7,6 +7,7 @@ import JavaScript from "tree-sitter-javascript";
 import TS from "tree-sitter-typescript";
 import { getReference } from "./queries/comment.ts";
 import { queries } from "./queries/index.ts";
+import { importQuery } from "./queries/import.ts";
 import type { Context } from "./queries/types.ts";
 
 export interface ParseResult {
@@ -88,18 +89,11 @@ export function parseSource(source: string, path: string): ParseResult {
         }
     }
 
-    const importQuery = new Parser.Query(
-        language,
-        `
-      (import_statement
-        source: (string (string_fragment) @import))
-    `,
-    );
-
-    for (const match of importQuery.matches(tree.rootNode)) {
-        const node = match.captures.find((c) => c.name === "import")?.node;
-        if (node) {
-            imports.push(node.text);
+    const importTreeQuery = new Parser.Query(language, importQuery.pattern);
+    for (const match of importTreeQuery.matches(tree.rootNode)) {
+        const imp = importQuery.extract(match);
+        if (imp) {
+            imports.push(imp);
         }
     }
 

--- a/extract/src/queries/import.ts
+++ b/extract/src/queries/import.ts
@@ -1,0 +1,31 @@
+import type Parser from "tree-sitter";
+import type { ImportQuerySpec } from "./types.ts";
+
+export const importQuery: ImportQuerySpec = {
+    pattern: `
+    [
+      (import_statement
+        source: (string (string_fragment) @import))
+      (export_statement
+        source: (string (string_fragment) @import))
+      (call_expression
+        function: (identifier) @func
+        arguments: (arguments (string (string_fragment) @import))
+        (#eq? @func "require"))
+      (call_expression
+        function: (member_expression
+            object: (identifier) @obj
+            property: (property_identifier) @method)
+        arguments: (arguments (string (string_fragment) @import))
+        (#eq? @obj "require")
+        (#eq? @method "resolve"))
+      (call_expression
+        function: (import)
+        arguments: (arguments (string (string_fragment) @import)))
+    ]
+  `,
+    extract(match: Parser.QueryMatch): string | undefined {
+        const node = match.captures.find((c) => c.name === "import")?.node;
+        return node?.text;
+    },
+};

--- a/extract/src/queries/tests/fixtures/context.ts
+++ b/extract/src/queries/tests/fixtures/context.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { context } from "@let-value/translate";
 
 context("ctx").msg("hello");

--- a/extract/src/queries/tests/fixtures/imports.ts
+++ b/extract/src/queries/tests/fixtures/imports.ts
@@ -1,0 +1,13 @@
+// @ts-nocheck
+import defaultExport from "default-export";
+import { named } from "named-export";
+import * as ns from "namespace-export";
+import "side-effect";
+export * from "export-all";
+export { default as alias } from "export-from";
+const cjs = require("cjs-module");
+const resolved = require.resolve("resolved-module");
+import("dynamic-import");
+async function load() {
+    await import("async-import");
+}

--- a/extract/src/queries/tests/import.test.ts
+++ b/extract/src/queries/tests/import.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { suite, test } from "node:test";
+import { importQuery } from "../import.ts";
+import { getMatches } from "./utils.ts";
+
+const fixture = readFileSync(new URL("./fixtures/imports.ts", import.meta.url)).toString();
+
+const paths = ["test.js", "test.cjs", "test.mjs", "test.ts", "test.tsx"];
+
+suite("should extract imports", () =>
+    paths.forEach((path) => {
+        test(path, () => {
+            const matches = getMatches(fixture, path, importQuery);
+            assert.deepEqual(matches, [
+                "default-export",
+                "named-export",
+                "namespace-export",
+                "side-effect",
+                "export-all",
+                "export-from",
+                "cjs-module",
+                "resolved-module",
+                "dynamic-import",
+                "async-import",
+            ]);
+        });
+    }),
+);

--- a/extract/src/queries/tests/utils.ts
+++ b/extract/src/queries/tests/utils.ts
@@ -1,15 +1,19 @@
 import Parser from "tree-sitter";
 import { getParser } from "../../parse.ts";
-import type { QuerySpec } from "../types.ts";
 
-export function getMatches(source: string, path: string, spec: QuerySpec) {
+interface AnyQuerySpec<T> {
+    pattern: string;
+    extract(match: Parser.QueryMatch): T | undefined;
+}
+
+export function getMatches<T>(source: string, path: string, spec: AnyQuerySpec<T>) {
     const { parser, language } = getParser(path);
     const tree = parser.parse(source);
     const query = new Parser.Query(language, spec.pattern);
     const matches = query
         .matches(tree.rootNode)
-        .flatMap((match) => spec.extract(match))
-        .filter((match) => !!match);
+        .map((match) => spec.extract(match))
+        .filter((match): match is T => !!match);
 
     return matches;
 }

--- a/extract/src/queries/types.ts
+++ b/extract/src/queries/types.ts
@@ -15,3 +15,8 @@ export interface QuerySpec {
     pattern: string;
     extract(match: Parser.QueryMatch): MessageMatch | undefined;
 }
+
+export interface ImportQuerySpec {
+    pattern: string;
+    extract(match: Parser.QueryMatch): string | undefined;
+}


### PR DESCRIPTION
## Summary
- add tree-sitter query for capturing module imports
- use new import query during parsing
- test import query against esm, cjs and dynamic forms

## Testing
- `npm test -w extract`
- `npm run typecheck -w extract`
- `npm run check -w extract` *(fails: Cannot find module '@biomejs/cli-linux-x64/biome')*

------
https://chatgpt.com/codex/tasks/task_e_68b6d10b5910832f9d26d2f1f12d150b