### PR TITLE
Add import resolver tests and single-module resolution

### DIFF
--- a/extract/src/index.ts
+++ b/extract/src/index.ts
@@ -9,7 +9,7 @@ export type { ParseResult } from "./parse.ts";
 export { parseFile } from "./parse.ts";
 export type { Message } from "./po.ts";
 export { buildPo, collect } from "./po.ts";
-export { resolveImports } from "./walk.ts";
+export { resolveImports, resolveImport } from "./walk.ts";
 
 /** Walk the dependency graph starting from entry and collect raw messages. */
 export function extract(entry: string): GetTextTranslation[] {

--- a/extract/src/tests/fixtures/project/packages/app/src/alias/alias-module.ts
+++ b/extract/src/tests/fixtures/project/packages/app/src/alias/alias-module.ts
@@ -1,0 +1,1 @@
+export default "alias";

--- a/extract/src/tests/fixtures/project/packages/app/src/async-import.ts
+++ b/extract/src/tests/fixtures/project/packages/app/src/async-import.ts
@@ -1,0 +1,1 @@
+export default "async";

--- a/extract/src/tests/fixtures/project/packages/app/src/base-module.ts
+++ b/extract/src/tests/fixtures/project/packages/app/src/base-module.ts
@@ -1,0 +1,1 @@
+export default "base";

--- a/extract/src/tests/fixtures/project/packages/app/src/cjs-module.cjs
+++ b/extract/src/tests/fixtures/project/packages/app/src/cjs-module.cjs
@@ -1,0 +1,1 @@
+module.exports = "cjs";

--- a/extract/src/tests/fixtures/project/packages/app/src/default-export.ts
+++ b/extract/src/tests/fixtures/project/packages/app/src/default-export.ts
@@ -1,0 +1,1 @@
+export default "default";

--- a/extract/src/tests/fixtures/project/packages/app/src/dynamic-import.ts
+++ b/extract/src/tests/fixtures/project/packages/app/src/dynamic-import.ts
@@ -1,0 +1,1 @@
+export default "dynamic";

--- a/extract/src/tests/fixtures/project/packages/app/src/export-all.ts
+++ b/extract/src/tests/fixtures/project/packages/app/src/export-all.ts
@@ -1,0 +1,1 @@
+export * from "./named-export.js";

--- a/extract/src/tests/fixtures/project/packages/app/src/export-from.ts
+++ b/extract/src/tests/fixtures/project/packages/app/src/export-from.ts
@@ -1,0 +1,1 @@
+export { namedExport as something } from "./named-export.js";

--- a/extract/src/tests/fixtures/project/packages/app/src/index.ts
+++ b/extract/src/tests/fixtures/project/packages/app/src/index.ts
@@ -1,0 +1,15 @@
+import defaultExport from "./default-export";
+import { namedExport } from "./named-export.js";
+import * as namespaceExport from "./namespace-export";
+import "./side-effect.js";
+export * from "./export-all";
+export { something } from "./export-from";
+const cjs = require("./cjs-module.cjs");
+require.resolve("./resolved-module");
+import("./dynamic-import");
+async function load() {
+  await import("./async-import");
+}
+import alias from "@app/alias/alias-module";
+import base from "base-module";
+import lib from "@lib/resolved-module";

--- a/extract/src/tests/fixtures/project/packages/app/src/named-export.js
+++ b/extract/src/tests/fixtures/project/packages/app/src/named-export.js
@@ -1,0 +1,1 @@
+export const namedExport = "named";

--- a/extract/src/tests/fixtures/project/packages/app/src/namespace-export.ts
+++ b/extract/src/tests/fixtures/project/packages/app/src/namespace-export.ts
@@ -1,0 +1,1 @@
+export const value = "namespace";

--- a/extract/src/tests/fixtures/project/packages/app/src/resolved-module/index.ts
+++ b/extract/src/tests/fixtures/project/packages/app/src/resolved-module/index.ts
@@ -1,0 +1,1 @@
+export default "resolved";

--- a/extract/src/tests/fixtures/project/packages/app/src/side-effect.js
+++ b/extract/src/tests/fixtures/project/packages/app/src/side-effect.js
@@ -1,0 +1,1 @@
+console.log("side effect");

--- a/extract/src/tests/fixtures/project/packages/app/tsconfig.json
+++ b/extract/src/tests/fixtures/project/packages/app/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@app/*": ["src/*"],
+      "@lib/*": ["../lib/src/*"],
+      "base-module": ["src/base-module.ts"]
+    }
+  }
+}

--- a/extract/src/tests/fixtures/project/packages/lib/src/base-module.ts
+++ b/extract/src/tests/fixtures/project/packages/lib/src/base-module.ts
@@ -1,0 +1,1 @@
+export default "lib-base";

--- a/extract/src/tests/fixtures/project/packages/lib/src/index.ts
+++ b/extract/src/tests/fixtures/project/packages/lib/src/index.ts
@@ -1,0 +1,2 @@
+import base from "@lib/base-module";
+import appDefault from "@app/default-export";

--- a/extract/src/tests/fixtures/project/packages/lib/src/resolved-module/index.ts
+++ b/extract/src/tests/fixtures/project/packages/lib/src/resolved-module/index.ts
@@ -1,0 +1,1 @@
+export default "lib-resolved";

--- a/extract/src/tests/fixtures/project/packages/lib/tsconfig.json
+++ b/extract/src/tests/fixtures/project/packages/lib/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@lib/*": ["src/*"],
+      "@app/*": ["../app/src/*"]
+    }
+  }
+}

--- a/extract/src/tests/fixtures/project/tsconfig.json
+++ b/extract/src/tests/fixtures/project/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "packages/app" },
+    { "path": "packages/lib" }
+  ]
+}

--- a/extract/src/tests/walk.test.ts
+++ b/extract/src/tests/walk.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { suite, test } from "node:test";
+
+import { parseFile } from "../parse.ts";
+import { resolveImport, resolveImports } from "../walk.ts";
+
+const appEntryUrl = new URL("./fixtures/project/packages/app/src/index.ts", import.meta.url);
+const appEntryPath = fileURLToPath(appEntryUrl);
+const appRoot = path.dirname(appEntryPath);
+
+const libEntryUrl = new URL("./fixtures/project/packages/lib/src/index.ts", import.meta.url);
+const libEntryPath = fileURLToPath(libEntryUrl);
+const libRoot = path.dirname(libEntryPath);
+
+const appCases: Record<string, string> = {
+  "./default-export": path.join(appRoot, "default-export.ts"),
+  "./named-export.js": path.join(appRoot, "named-export.js"),
+  "./namespace-export": path.join(appRoot, "namespace-export.ts"),
+  "./side-effect.js": path.join(appRoot, "side-effect.js"),
+  "./export-all": path.join(appRoot, "export-all.ts"),
+  "./export-from": path.join(appRoot, "export-from.ts"),
+  "./cjs-module.cjs": path.join(appRoot, "cjs-module.cjs"),
+  "./resolved-module": path.join(appRoot, "resolved-module/index.ts"),
+  "./dynamic-import": path.join(appRoot, "dynamic-import.ts"),
+  "./async-import": path.join(appRoot, "async-import.ts"),
+  "@app/alias/alias-module": path.join(appRoot, "alias/alias-module.ts"),
+  "base-module": path.join(appRoot, "base-module.ts"),
+  "@lib/resolved-module": path.join(libRoot, "resolved-module/index.ts"),
+};
+
+suite("resolveImport - app", () => {
+  for (const [spec, expected] of Object.entries(appCases)) {
+    test(spec, () => {
+      assert.equal(resolveImport(appEntryPath, spec), expected);
+    });
+  }
+});
+
+suite("resolveImports - app", () => {
+  test("resolves all imports from app index", () => {
+    const { imports } = parseFile(appEntryPath);
+    const resolved = resolveImports(appEntryPath, imports).sort();
+    const expected = Object.values(appCases).sort();
+    assert.deepEqual(resolved, expected);
+  });
+});
+
+const libCases: Record<string, string> = {
+  "@lib/base-module": path.join(libRoot, "base-module.ts"),
+  "@app/default-export": path.join(appRoot, "default-export.ts"),
+};
+
+suite("resolveImport - lib", () => {
+  for (const [spec, expected] of Object.entries(libCases)) {
+    test(spec, () => {
+      assert.equal(resolveImport(libEntryPath, spec), expected);
+    });
+  }
+});
+
+suite("resolveImports - lib", () => {
+  test("resolves all imports from lib index", () => {
+    const { imports } = parseFile(libEntryPath);
+    const resolved = resolveImports(libEntryPath, imports).sort();
+    const expected = Object.values(libCases).sort();
+    assert.deepEqual(resolved, expected);
+  });
+});

--- a/extract/src/walk.ts
+++ b/extract/src/walk.ts
@@ -1,5 +1,51 @@
+import fs from "node:fs";
 import path from "node:path";
-import resolver from "oxc-resolver";
+import { ResolverFactory } from "oxc-resolver";
+
+function findTsconfig(dir: string): string | undefined {
+    let current = dir;
+    // Walk up directories to find nearest tsconfig.json
+    while (true) {
+        const config = path.join(current, "tsconfig.json");
+        if (fs.existsSync(config)) {
+            return config;
+        }
+        const parent = path.dirname(current);
+        if (parent === current) {
+            return undefined;
+        }
+        current = parent;
+    }
+}
+
+const resolverCache = new Map<string, ResolverFactory>();
+
+function getResolver(dir: string) {
+    const tsconfig = findTsconfig(dir);
+    const key = tsconfig ?? "__default__";
+    let resolver = resolverCache.get(key);
+    if (!resolver) {
+        resolver = new ResolverFactory({
+            extensions: [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".json"],
+            conditionNames: ["import", "require", "node"],
+            ...(tsconfig ? { tsconfig: { configFile: tsconfig } } : {}),
+        });
+        resolverCache.set(key, resolver);
+    }
+    return resolver;
+}
+
+function resolveFromDir(dir: string, spec: string): string | undefined {
+    const resolver = getResolver(dir);
+    const res = resolver.sync(dir, spec) as { path?: string };
+    return res.path;
+}
+
+/** Resolve a single import specifier relative to a file. */
+export function resolveImport(file: string, spec: string): string | undefined {
+    const dir = path.dirname(path.resolve(file));
+    return resolveFromDir(dir, spec);
+}
 
 /**
  * Resolve a list of import specifiers relative to a file.
@@ -10,6 +56,7 @@ import resolver from "oxc-resolver";
  */
 export function resolveImports(file: string, imports: string[]): string[] {
     const dir = path.dirname(path.resolve(file));
+    const resolver = getResolver(dir);
     const resolved: string[] = [];
     for (const spec of imports) {
         const res = resolver.sync(dir, spec) as { path?: string };

--- a/extract/tsconfig.json
+++ b/extract/tsconfig.json
@@ -8,5 +8,6 @@
         "outDir": "dist"
     },
     "include": ["src/**/*.ts", "bin/**/*.ts", "index.ts"],
+    "exclude": ["src/tests/fixtures"],
     "references": [{ "path": "../translate" }]
 }


### PR DESCRIPTION
## Summary
- reuse a cached resolver keyed by tsconfig to avoid reconstructing import resolvers
- introduce monorepo-style fixtures with package-specific path aliases to cover cross-package resolution

## Testing
- `npm test`
- `npm run typecheck`
- `npm run check` *(fails: Cannot find module '@biomejs/cli-linux-x64/biome')*


------
https://chatgpt.com/codex/tasks/task_e_68b6d7c72d3c832faea07301f55b6e42