### PR TITLE
feat: add async translation loading to translator

### DIFF
--- a/translate/test/ngettext.test.ts
+++ b/translate/test/ngettext.test.ts
@@ -21,9 +21,9 @@ test("ngettext handles English plurals", () => {
     assert.equal(t.ngettext(msg`${2} apple`, msg`${2} apples`, 2), "2 apples");
 });
 
-test("ngettext handles Russian plurals", () => {
+test("ngettext handles Russian plurals", async () => {
     const t = new Translator("en", translations);
-    t.useLocale("ru");
+    await t.useLocale("ru");
     assert.equal(t.ngettext(msg`${1} apple`, msg`${1} apples`, 1), "1 яблоко");
     assert.equal(t.ngettext(msg`${2} apple`, msg`${2} apples`, 2), "2 яблока");
     assert.equal(t.ngettext(msg`${5} apple`, msg`${5} apples`, 5), "5 яблок");
@@ -59,9 +59,9 @@ test("ngettext handles context-aware plural helper", () => {
     assert.equal(t.npgettext(apples), "2 Apple устройства");
 });
 
-test("ngettext returns default forms when translation missing", () => {
+test("ngettext returns default forms when translation missing", async () => {
     const t = new Translator("en", {});
-    t.useLocale("fr");
+    await t.useLocale("fr");
     assert.equal(t.ngettext(msg`${1} apple`, msg`${1} apples`, 1), "1 apple");
     assert.equal(t.ngettext(msg`${2} apple`, msg`${2} apples`, 2), "2 apples");
 });

--- a/translate/test/pgettext.test.ts
+++ b/translate/test/pgettext.test.ts
@@ -13,11 +13,11 @@ test("pgettext handles context-specific translations", () => {
     assert.equal(t.pgettext("adjective", "Open"), "Открытый");
 });
 
-test("gettext handles context-aware messages", () => {
+test("gettext handles context-aware messages", async () => {
     const ruPo = fs.readFileSync(new URL("./fixtures/ru.po", import.meta.url));
     const translations = { ru: gettextParser.po.parse(ruPo) };
     const t = new Translator("en", translations);
-    t.useLocale("ru");
+    await t.useLocale("ru");
     const verb = context("verb");
     assert.equal(t.pgettext(verb.msg("Open")), "Открыть");
 });


### PR DESCRIPTION
## Summary
- support async translation loaders and lazy `useLocale`
- add `load` method for on-demand locale registration
- update tests for asynchronous usage

## Testing
- `npm test`
- `npm run check --workspace=@let-value/translate` *(fails: Cannot find module '@biomejs/cli-linux-x64/biome')*

------
https://chatgpt.com/codex/tasks/task_e_68b7ee8d2c6c832f81d9fc1ea128c85a