### PR TITLE
feat: flag invalid context builder usage

### DIFF
--- a/extract/src/queries/index.ts
+++ b/extract/src/queries/index.ts
@@ -1,4 +1,4 @@
-import { contextMsgQuery, contextPluralQuery } from "./context.ts";
+import { contextInvalidQuery, contextMsgQuery, contextPluralQuery } from "./context.ts";
 import { gettextInvalidQuery, gettextQuery } from "./gettext.ts";
 import { messageInvalidQuery, messageQuery } from "./message.ts";
 import { ngettextQuery } from "./ngettext.ts";
@@ -20,4 +20,5 @@ export const queries: QuerySpec[] = [
     npgettextQuery,
     contextMsgQuery,
     contextPluralQuery,
+    contextInvalidQuery,
 ];

--- a/extract/src/queries/tests/context.test.ts
+++ b/extract/src/queries/tests/context.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { suite, test } from "node:test";
-import { contextMsgQuery } from "../context.ts";
+import { contextInvalidQuery, contextMsgQuery } from "../context.ts";
 import { getMatches } from "./utils.ts";
 
 const fixture = readFileSync(new URL("./fixtures/context.ts", import.meta.url)).toString();
@@ -70,6 +70,23 @@ suite("should extract context builder messages", () =>
                     },
                     {
                         error: "context.message() template expressions must be simple identifiers",
+                        translation: undefined,
+                    },
+                ],
+            );
+        });
+    }),
+);
+
+suite("should extract context builder errors", () =>
+    paths.forEach((path) => {
+        test(path, () => {
+            const matches = getMatches(fixture, path, contextInvalidQuery);
+            assert.deepEqual(
+                matches.map(({ error, translation }) => ({ error, translation })),
+                [
+                    {
+                        error: "context() must be used with message() or plural() in the same expression",
                         translation: undefined,
                     },
                 ],

--- a/extract/src/queries/tests/fixtures/context.ts
+++ b/extract/src/queries/tests/fixtures/context.ts
@@ -17,3 +17,6 @@ context("ctx").message`Hello, ${name}!`;
 
 context("ctx").message`Hi, ${name.toUpperCase()}!`;
 context("ctx").message`Hi, ${name.length}!`;
+
+const ctx = context("fruit");
+ctx.message("apple");


### PR DESCRIPTION
## Summary
- detect context() calls not immediately followed by message or plural
- test invalid context builder usage

## Testing
- `npm test`
- `npm run typecheck -w extract` (fails: Argument of type 'string | undefined' is not assignable...)
- `npm run check -w extract` (fails: Formatter would have printed the following content)


------
https://chatgpt.com/codex/tasks/task_e_68b8284c01d4832f8b539dffdcc0fbc6