### PR TITLE
feat: support template literal contexts

### DIFF
--- a/translate/src/messages.ts
+++ b/translate/src/messages.ts
@@ -93,13 +93,26 @@ export interface ContextBuilder {
 const baseMessage = message;
 const basePlural = plural;
 
-export function context(context: string): ContextBuilder {
+export function context<T extends string>(
+    context: StrictStaticString<T>,
+): ContextBuilder;
+export function context(
+    strings: TemplateStringsArray,
+    ...values: never[]
+): ContextBuilder;
+export function context<T extends string>(
+    ...args: [StrictStaticString<T>] | [TemplateStringsArray, ...never[]]
+): ContextBuilder {
+    const [source] = args as [StrictStaticString<T> | TemplateStringsArray];
+
+    const ctx = typeof source === "string" ? source : source[0];
+
     function message<T extends string>(...args: MessageArgs<T>): ContextMessage {
-        return { id: baseMessage(...args), context };
+        return { id: baseMessage(...args), context: ctx };
     }
 
     function plural(...forms: PluralArgs): ContextPluralMessage {
-        return { id: basePlural(...forms), context };
+        return { id: basePlural(...forms), context: ctx };
     }
 
     return {

--- a/translate/test/context.test.ts
+++ b/translate/test/context.test.ts
@@ -17,3 +17,17 @@ test("context builder attaches context to plural", () => {
     assert.equal(p.id.forms[0].msgstr, "${0} apple");
     assert.equal(p.id.forms[1].msgstr, "${0} apples");
 });
+
+test("context builder accepts template literals", () => {
+    const fruit = context`fruit`;
+    assert.deepEqual(fruit.message`apple`, {
+        context: "fruit",
+        id: { msgid: "apple", msgstr: "apple", values: [] },
+    });
+});
+
+test("context builder rejects interpolations", () => {
+    const category = "citrus";
+    // @ts-expect-error context cannot contain expressions
+    void context`fruit${category}`;
+});

--- a/translate/test/translator-context-message.test.ts
+++ b/translate/test/translator-context-message.test.ts
@@ -33,3 +33,15 @@ test("pgettext alias works", () => {
     const t = new Translator("en", {});
     assert.equal(t.pgettext("ctx", "X"), "X");
 });
+
+test("translator context accepts template literals", () => {
+    const t = new Translator("en", {});
+    assert.equal(t.context`verb`.message`Open`, "Open");
+});
+
+test("translator context rejects interpolations", () => {
+    const t = new Translator("en", {});
+    const category = "test";
+    // @ts-expect-error context cannot contain expressions
+    void t.context`fruit${category}`;
+});

--- a/translate/test/translator-context-plural.test.ts
+++ b/translate/test/translator-context-plural.test.ts
@@ -63,3 +63,11 @@ test("npgettext alias works", () => {
     const t = new Translator("en", translations);
     assert.equal(t.npgettext("ctx", message`${1} apple`, message`${1} apples`, 1), "1 apple");
 });
+
+test("translator context accepts template literals for plurals", () => {
+    const t = new Translator("en", translations);
+    assert.equal(
+        t.context`company`.plural(message`${1} apple`, message`${1} apples`, 1),
+        "1 apple",
+    );
+});


### PR DESCRIPTION
## Summary
- allow `context` builder to be invoked as a tagged template and reject interpolated values
- support template literal contexts within `Translator`
- cover context template usage and invalid interpolation with new tests

## Testing
- `npm test`
- `npm run typecheck`
- `npm run check` *(fails: Biome reports formatting issues across the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68b82b073fe0832f83b6a4535d26b49e