### PR TITLE
feat: introduce core extraction plugin

### DIFF
--- a/extract/bin/cli.ts
+++ b/extract/bin/cli.ts
@@ -8,7 +8,7 @@ if (!entry) {
     process.exit(1);
 }
 
-const po = extractPo(entry, locale);
+const po = await extractPo(entry, locale);
 if (out) {
     fs.writeFileSync(out, po);
 } else {

--- a/extract/src/core.ts
+++ b/extract/src/core.ts
@@ -1,0 +1,63 @@
+import fs from "node:fs";
+import path from "node:path";
+import type {
+    ExtractBuild,
+    ExtractorPlugin,
+    ExtractArgs,
+    LoadArgs,
+    ResolveArgs,
+} from "./plugin.ts";
+import type { GetTextTranslation } from "gettext-parser";
+import { parseSource } from "./parse.ts";
+import { resolveImport } from "./walk.ts";
+import { buildPo, collect, type Message } from "./po.ts";
+
+export interface CorePlugin extends ExtractorPlugin {
+    messages: Message[];
+    po: string;
+}
+
+export function corePlugin(): CorePlugin {
+    const plugin: CorePlugin = {
+        name: "core",
+        messages: [],
+        po: "",
+        setup(build: ExtractBuild) {
+            build.onResolve({ filter: /.*/ }, ({ path: spec, importer }: ResolveArgs) => {
+                if (importer) {
+                    return resolveImport(importer, spec);
+                }
+                return path.resolve(spec);
+            });
+
+            build.onLoad({ filter: /.*/ }, ({ path }: LoadArgs) => {
+                const contents = fs.readFileSync(path, "utf8");
+                return { contents };
+            });
+
+            build.onExtract(
+                { filter: /\.[jt]sx?$/ },
+                ({ path, contents }: ExtractArgs) => {
+                    const { translations, imports } = parseSource(contents, path);
+                    return { messages: translations, imports };
+                },
+            );
+
+            build.onCollect((messages: GetTextTranslation[]) => {
+                plugin.messages = collect(messages);
+            });
+
+            build.onGenerate((locale: string, messages: GetTextTranslation[]) => {
+                if (!locale) return;
+                if (plugin.messages.length === 0) {
+                    plugin.messages = collect(messages);
+                }
+                plugin.po = buildPo(locale, plugin.messages);
+            });
+        },
+    };
+
+    return plugin;
+}
+
+export { corePlugin as default };

--- a/extract/src/index.ts
+++ b/extract/src/index.ts
@@ -1,48 +1,26 @@
 import path from "node:path";
 import type { GetTextTranslation } from "gettext-parser";
 
-import { parseFile } from "./parse.ts";
-import { buildPo as buildPoImpl, collect as collectImpl } from "./po.ts";
-import { resolveImports } from "./walk.ts";
+import { runPipeline } from "./plugin.ts";
+import { corePlugin } from "./core.ts";
+
 
 export type { ParseResult } from "./parse.ts";
 export { parseFile } from "./parse.ts";
 export type { Message } from "./po.ts";
 export { buildPo, collect } from "./po.ts";
 export { resolveImport, resolveImports } from "./walk.ts";
+export { corePlugin } from "./core.ts";
+export { runPipeline } from "./plugin.ts";
 
 /** Walk the dependency graph starting from entry and collect raw messages. */
-export function extract(entry: string): GetTextTranslation[] {
-    const queue = [path.resolve(entry)];
-    const visited = new Set<string>();
-    const all: GetTextTranslation[] = [];
-
-    while (queue.length) {
-        const file = queue.shift();
-        if (!file) {
-            break;
-        }
-
-        if (visited.has(file)) {
-            continue;
-        }
-        visited.add(file);
-
-        const { translations, imports } = parseFile(file);
-        all.push(...translations);
-
-        const resolved = resolveImports(file, imports);
-        for (const next of resolved) {
-            if (!visited.has(next)) queue.push(next);
-        }
-    }
-
-    return all;
+export async function extract(entry: string): Promise<GetTextTranslation[]> {
+    return runPipeline(path.resolve(entry), [corePlugin()], "");
 }
 
 /** Convenience function to collect and build a PO file. */
-export function extractPo(entry: string, locale: string): string {
-    const raw = extract(entry);
-    const messages = collectImpl(raw);
-    return buildPoImpl(locale, messages);
+export async function extractPo(entry: string, locale: string): Promise<string> {
+    const plugin = corePlugin();
+    await runPipeline(path.resolve(entry), [plugin], locale);
+    return plugin.po;
 }

--- a/extract/src/plugin.ts
+++ b/extract/src/plugin.ts
@@ -1,0 +1,176 @@
+import type { GetTextTranslation } from "gettext-parser";
+
+/** Utility type allowing a hook to return a value or a promise. */
+type MaybePromise<T> = T | Promise<T>;
+
+/** Shared context available to all hooks and plugins. */
+export interface ExtractContext {
+    /** Path to the original entry file being processed. */
+    entry: string;
+    /** Destination directory for generated artifacts. */
+    dest: string;
+    /** Arbitrary cache shared across plugins. */
+    cache: Map<string, unknown>;
+    /** Shared mutable data for coordination between plugins. */
+    shared: Record<string, unknown>;
+    /** Queue additional files for the pipeline to process. */
+    emitFile(path: string, importer?: string): void;
+}
+
+export interface ResolveArgs {
+    path: string;
+    importer?: string;
+}
+
+export type ResolveResult = string | undefined;
+export type ResolveHook = (args: ResolveArgs, ctx: ExtractContext) => MaybePromise<ResolveResult>;
+
+export interface LoadArgs {
+    path: string;
+}
+
+export interface LoadResult {
+    contents: string;
+}
+export type LoadHook = (args: LoadArgs, ctx: ExtractContext) => MaybePromise<LoadResult | undefined>;
+
+export interface ExtractArgs {
+    path: string;
+    contents: string;
+}
+
+export interface ExtractResult {
+    messages: GetTextTranslation[];
+    imports: string[];
+}
+export type ExtractHook = (args: ExtractArgs, ctx: ExtractContext) => MaybePromise<ExtractResult | undefined>;
+
+export type CollectHook = (messages: GetTextTranslation[], ctx: ExtractContext) => MaybePromise<void>;
+export type GenerateHook = (locale: string, messages: GetTextTranslation[], ctx: ExtractContext) => MaybePromise<void>;
+
+export interface ExtractBuild {
+    onResolve(options: { filter: RegExp }, hook: ResolveHook): void;
+    onLoad(options: { filter: RegExp }, hook: LoadHook): void;
+    onExtract(options: { filter: RegExp }, hook: ExtractHook): void;
+    onCollect(hook: CollectHook): void;
+    onGenerate(hook: GenerateHook): void;
+    /** Allow plugins to enqueue new files during setup. */
+    emitFile(path: string, importer?: string): void;
+    context: ExtractContext;
+}
+
+export interface ExtractorPlugin {
+    name: string;
+    setup(build: ExtractBuild): void;
+}
+
+/**
+ * Run the extraction pipeline starting from an entry file using the provided plugins.
+ * Hooks are executed in order: resolve -> load -> extract -> collect -> generate.
+ */
+export async function runPipeline(
+    entry: string,
+    plugins: ExtractorPlugin[],
+    locale: string,
+    opts: { dest?: string } = {},
+): Promise<GetTextTranslation[]> {
+    const queue: { path: string; importer?: string }[] = [{ path: entry }];
+    const context: ExtractContext = {
+        entry,
+        dest: opts.dest ?? process.cwd(),
+        cache: new Map(),
+        shared: {},
+        emitFile(path, importer) {
+            queue.push({ path, importer });
+        },
+    };
+
+    const resolves: { filter: RegExp; hook: ResolveHook }[] = [];
+    const loads: { filter: RegExp; hook: LoadHook }[] = [];
+    const extracts: { filter: RegExp; hook: ExtractHook }[] = [];
+    const collects: CollectHook[] = [];
+    const generates: GenerateHook[] = [];
+
+    const build: ExtractBuild = {
+        onResolve({ filter }, hook) {
+            resolves.push({ filter, hook });
+        },
+        onLoad({ filter }, hook) {
+            loads.push({ filter, hook });
+        },
+        onExtract({ filter }, hook) {
+            extracts.push({ filter, hook });
+        },
+        onCollect(hook) {
+            collects.push(hook);
+        },
+        onGenerate(hook) {
+            generates.push(hook);
+        },
+        emitFile: context.emitFile,
+        context,
+    };
+
+    for (const plugin of plugins) {
+        plugin.setup(build);
+    }
+
+    const visited = new Set<string>();
+    const messages: GetTextTranslation[] = [];
+
+    async function applyResolve(path: string, importer?: string): Promise<string | undefined> {
+        for (const { filter, hook } of resolves) {
+            if (!filter.test(path)) continue;
+            const result = await hook({ path, importer }, context);
+            if (result) return result;
+        }
+        return undefined;
+    }
+
+    async function applyLoad(path: string): Promise<string | undefined> {
+        for (const { filter, hook } of loads) {
+            if (!filter.test(path)) continue;
+            const result = await hook({ path }, context);
+            if (result) return result.contents;
+        }
+        return undefined;
+    }
+
+    async function applyExtract(path: string, contents: string): Promise<ExtractResult | undefined> {
+        for (const { filter, hook } of extracts) {
+            if (!filter.test(path)) continue;
+            const result = await hook({ path, contents }, context);
+            if (result) return result;
+        }
+        return undefined;
+    }
+
+    while (queue.length) {
+        const { path, importer } = queue.shift()!;
+        const resolved = await applyResolve(path, importer);
+        if (!resolved || visited.has(resolved)) continue;
+        visited.add(resolved);
+
+        const contents = await applyLoad(resolved);
+        if (contents == null) continue;
+
+        const extracted = await applyExtract(resolved, contents);
+        if (!extracted) continue;
+
+        messages.push(...extracted.messages);
+        for (const imp of extracted.imports) {
+            context.emitFile(imp, resolved);
+        }
+    }
+
+    for (const hook of collects) {
+        await hook(messages, context);
+    }
+
+    for (const hook of generates) {
+        await hook(locale, messages, context);
+    }
+
+    return messages;
+}
+


### PR DESCRIPTION
## Summary
- move resolution, parsing, and PO handling into a core extractor plugin
- register and export corePlugin via new runPipeline API
- update CLI to use async extractPo

## Testing
- `npm test`
- `npm run typecheck`
- `npm run check` *(fails: Cannot find module '@biomejs/cli-linux-x64/biome')*

------
https://chatgpt.com/codex/tasks/task_e_68b853c92548832fb29bc7a74f69141d