### PR TITLE
feat(extract): add configuration helper

### DIFF
--- a/extract/src/configuration.ts
+++ b/extract/src/configuration.ts
@@ -1,0 +1,29 @@
+import type { ExtractorPlugin } from "./plugin.ts";
+import { core } from "./plugins/core/core.ts";
+import { po } from "./plugins/po/po.ts";
+
+export interface UserConfig {
+    plugins?: ExtractorPlugin[] | ((plugins: ExtractorPlugin[]) => ExtractorPlugin[]);
+    entrypoints: string | string[];
+}
+
+export interface ResolvedConfig {
+    plugins: ExtractorPlugin[];
+    entrypoints: string[];
+}
+
+const defaultPlugins: ExtractorPlugin[] = [core(), po()];
+
+export function defineConfig(config: UserConfig): ResolvedConfig {
+    let plugins: ExtractorPlugin[];
+    const user = config.plugins;
+    if (typeof user === "function") {
+        plugins = user(defaultPlugins);
+    } else if (Array.isArray(user)) {
+        plugins = [...defaultPlugins, ...user];
+    } else {
+        plugins = defaultPlugins;
+    }
+    const entrypoints = Array.isArray(config.entrypoints) ? config.entrypoints : [config.entrypoints];
+    return { plugins, entrypoints };
+}

--- a/extract/src/index.ts
+++ b/extract/src/index.ts
@@ -1,0 +1,1 @@
+export { defineConfig } from "./configuration.ts";

--- a/extract/src/tests/configuration.test.ts
+++ b/extract/src/tests/configuration.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { defineConfig } from "../configuration.ts";
+import type { ExtractorPlugin } from "../plugin.ts";
+
+const mockPlugin: ExtractorPlugin = { name: "mock", setup() {} };
+
+test("appends plugins when array provided", () => {
+    const cfg = defineConfig({ entrypoints: "src/index.ts", plugins: [mockPlugin] });
+    assert.equal(cfg.plugins.length, 3);
+    assert.equal(cfg.plugins.at(-1), mockPlugin);
+});
+
+test("allows overriding default plugins with function", () => {
+    const cfg = defineConfig({
+        entrypoints: "src/index.ts",
+        plugins(defaults) {
+            return defaults.filter((p) => p.name !== "po");
+        },
+    });
+    assert.deepEqual(
+        cfg.plugins.map((p) => p.name),
+        ["core"],
+    );
+});
+
+test("normalizes single entrypoint to array", () => {
+    const cfg = defineConfig({ entrypoints: "src/index.ts" });
+    assert.deepEqual(cfg.entrypoints, ["src/index.ts"]);
+});


### PR DESCRIPTION
## Summary
- add `defineConfig` helper for extract package with plugin customization and entrypoint support
- expose helper via package index
- add tests for configuration merging and entrypoint normalization

## Testing
- `npm run check --workspace extract`
- `npm test --workspace extract`
- `npm run typecheck --workspace extract` *(fails: Module '../src/index.ts' has no exported member 'extractPo')*


------
https://chatgpt.com/codex/tasks/task_e_68ba8ef27b70832fa25750f0342e9dbb