### PR TITLE
feat: add extraction metadata

### DIFF
--- a/extract/src/plugin.ts
+++ b/extract/src/plugin.ts
@@ -6,6 +6,8 @@ export interface ExtractContext {
     entry: string;
     dest: string;
     config: ResolvedConfig;
+    /** Timestamp when extraction started. */
+    generatedAt: Date;
 }
 
 export interface ResolveArgs {

--- a/extract/src/plugins/po/tests/header.test.ts
+++ b/extract/src/plugins/po/tests/header.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { merge, formatDate } from "../po.ts";
+import type { CollectResult } from "../../../plugin.ts";
+
+test("sets POT-Creation-Date header from context timestamp", () => {
+    const timestamp = new Date("2023-01-02T03:04:00Z");
+    const collected: CollectResult[] = [
+        {
+            entrypoint: "entry.ts",
+            path: "entry.ts",
+            destination: "messages.po",
+            translations: { "": {} },
+        },
+    ];
+    const out = merge("en", collected, undefined, "mark", timestamp);
+    assert.ok(out.includes(`POT-Creation-Date: ${formatDate(timestamp)}`));
+});

--- a/extract/src/run.ts
+++ b/extract/src/run.ts
@@ -30,6 +30,7 @@ export async function run(
         entry: entrypoint,
         dest: opts.dest ?? process.cwd(),
         config: opts.config,
+        generatedAt: new Date(),
     };
 
     const resolves: { filter: RegExp; hook: ResolveHook }[] = [];


### PR DESCRIPTION
## Summary
- expose extraction timestamp to plugins
- include POT-Creation-Date and generator metadata when generating PO files
- test PO header generation

## Testing
- `npm test`
- `npm run typecheck` *(fails: Module '../src/index.ts' has no exported member 'extractPo', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68badd60b958832f8dd58d724021ccf1