### PR TITLE
feat(react): tighten message and plural types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -806,9 +806,18 @@
             "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.12.tgz",
             "integrity": "sha512-cMoR+FoAf/Jyq6+Df2/Z41jISvGZZ2eTlnsaJRptmZ76Caldwy1odD4xTr/gNV9VLj0AWgg/nmkevIyUfIIq5w==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "csstype": "^3.0.2"
+            }
+        },
+        "node_modules/@types/react-dom": {
+            "version": "19.0.0",
+            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.0.0.tgz",
+            "integrity": "sha512-1KfiQKsH1o00p9m5ag12axHQSb3FOU9H20UTrujVSkNhuCrRHiQWFqgEnTNK5ZNfnzZv8UWrnXVqCmCF9fgY3w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/react": "*"
             }
         },
         "node_modules/@types/readable-stream": {
@@ -1281,12 +1290,6 @@
                 "jiti": "lib/jiti-cli.mjs"
             }
         },
-        "node_modules/js-tokens": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-            "license": "MIT"
-        },
         "node_modules/jsesc": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -1298,18 +1301,6 @@
             },
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/loose-envify": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-            "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-            "license": "MIT",
-            "dependencies": {
-                "js-tokens": "^3.0.0 || ^4.0.0"
-            },
-            "bin": {
-                "loose-envify": "cli.js"
             }
         },
         "node_modules/lru-cache": {
@@ -1487,15 +1478,26 @@
             }
         },
         "node_modules/react": {
-            "version": "18.3.1",
-            "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-            "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+            "version": "19.0.0",
+            "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
+            "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
+            "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "loose-envify": "^1.1.0"
-            },
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/react-dom": {
+            "version": "19.0.0",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz",
+            "integrity": "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "scheduler": "^0.25.0"
+            },
+            "peerDependencies": {
+                "react": "^19.0.0"
             }
         },
         "node_modules/readable-stream": {
@@ -1629,6 +1631,12 @@
         "node_modules/safer-buffer": {
             "version": "2.1.2",
             "license": "MIT"
+        },
+        "node_modules/scheduler": {
+            "version": "0.25.0",
+            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
+            "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
+            "dev": true
         },
         "node_modules/semver": {
             "version": "7.7.2",
@@ -2099,16 +2107,18 @@
             "name": "@let-value/translate-react",
             "version": "1.0.0",
             "dependencies": {
-                "@let-value/translate": "^1.0.0",
-                "react": "^18.2.0"
+                "@let-value/translate": "^1.0.0"
             },
             "devDependencies": {
                 "@types/gettext-parser": "8.0.0",
                 "@types/react": "18.2.46",
+                "@types/react-dom": "^19.0.0",
+                "react": "^19.0.0",
+                "react-dom": "^19.0.0",
                 "typescript": "5.9.2"
             },
             "peerDependencies": {
-                "react": ">=18"
+                "react": ">=19"
             }
         },
         "react/node_modules/@types/react": {

--- a/react/package.json
+++ b/react/package.json
@@ -18,6 +18,9 @@
     "devDependencies": {
         "@types/gettext-parser": "8.0.0",
         "@types/react": "18.2.46",
+        "@types/react-dom": "^19.0.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
         "typescript": "5.9.2"
     },
     "peerDependencies": {

--- a/react/src/Message.ts
+++ b/react/src/Message.ts
@@ -1,16 +1,16 @@
-import type { ReactNode } from "react";
+import { createElement, Fragment, type ReactNode } from "react";
 
-import { useTranslations } from "./useTranslations.tsx";
-import { buildMessageFromChildren } from "./utils.ts";
+import { useTranslations } from "./useTranslations.ts";
+import { buildMessageFromChildren, type StrictReactNode } from "./utils.ts";
 
-export interface MessageProps {
+export interface MessageProps<T extends ReactNode> {
     context?: string;
-    children: ReactNode;
+    children: StrictReactNode<T>;
 }
 
-export function Message({ context, children }: MessageProps) {
+export function Message<T extends ReactNode>({ context, children }: MessageProps<T>) {
     const translator = useTranslations();
-    const { id, values } = buildMessageFromChildren(children);
+    const { id, values } = buildMessageFromChildren(children as ReactNode);
 
     if (values.length === 0) {
         if (context) {
@@ -34,5 +34,5 @@ export function Message({ context, children }: MessageProps) {
         }
     }
 
-    return <>{result}</>;
+    return createElement(Fragment, null, ...result);
 }

--- a/react/src/Plural.ts
+++ b/react/src/Plural.ts
@@ -1,15 +1,15 @@
-import type { ReactNode } from "react";
+import { createElement, Fragment, type ReactNode } from "react";
 
-import { useTranslations } from "./useTranslations.tsx";
-import { buildMessageFromChildren } from "./utils.ts";
+import { useTranslations } from "./useTranslations.ts";
+import { buildMessageFromChildren, type StrictReactNode } from "./utils.ts";
 
-export interface PluralProps {
+export interface PluralProps<F extends readonly ReactNode[]> {
     number: number;
-    forms: ReactNode[];
+    forms: StrictReactNode<F>;
     context?: string;
 }
 
-export function Plural({ number, forms, context }: PluralProps) {
+export function Plural<F extends readonly ReactNode[]>({ number, forms, context }: PluralProps<F>) {
     const translator = useTranslations();
 
     const built = forms.map((child, i) => {
@@ -36,5 +36,5 @@ export function Plural({ number, forms, context }: PluralProps) {
         i += 3;
     }
 
-    return <>{result}</>;
+    return createElement(Fragment, null, ...result);
 }

--- a/react/src/TranslationsProvider.ts
+++ b/react/src/TranslationsProvider.ts
@@ -1,6 +1,6 @@
 import { Translator } from "@let-value/translate";
 import type { GetTextTranslations } from "gettext-parser";
-import { createContext, type ReactNode, useContext, useMemo } from "react";
+import { createContext, createElement, type ReactNode, useContext, useMemo } from "react";
 
 export const TranslatorContext = createContext<Translator | null>(null);
 
@@ -50,5 +50,5 @@ export function TranslationsProvider({ locale, translations = {}, children }: Tr
         throw translator.useLocale(locale);
     }
 
-    return <TranslatorContext.Provider value={translator}>{children}</TranslatorContext.Provider>;
+    return createElement(TranslatorContext.Provider, { value: translator }, children);
 }

--- a/react/src/index.ts
+++ b/react/src/index.ts
@@ -1,5 +1,5 @@
 export * from "@let-value/translate";
-export { Message } from "./Message.tsx";
-export { Plural } from "./Plural.tsx";
-export { TranslationsProvider, TranslatorContext } from "./TranslationsProvider.tsx";
-export { useTranslations } from "./useTranslations.tsx";
+export { Message } from "./Message.ts";
+export { Plural } from "./Plural.ts";
+export { TranslationsProvider, TranslatorContext } from "./TranslationsProvider.ts";
+export { useTranslations } from "./useTranslations.ts";

--- a/react/src/useTranslations.ts
+++ b/react/src/useTranslations.ts
@@ -2,7 +2,7 @@ import type { Translator } from "@let-value/translate";
 import type { GetTextTranslations } from "gettext-parser";
 import { useContext } from "react";
 
-import { TranslatorContext } from "./TranslationsProvider.tsx";
+import { TranslatorContext } from "./TranslationsProvider.ts";
 
 export function useTranslations(locale?: string): Translator {
     const translator = useContext(TranslatorContext);

--- a/react/src/utils.ts
+++ b/react/src/utils.ts
@@ -1,5 +1,27 @@
 import { Children, type ReactNode } from "react";
 
+export type IsUnion<T, U = T> = (T extends unknown ? (x: T) => 0 : never) extends (x: U) => 0
+    ? false
+    : true;
+
+export type StrictStaticString<T extends string> = string extends T
+    ? never
+    : IsUnion<T> extends true
+        ? never
+        : T;
+
+type StrictTuple<T extends readonly unknown[]> = T extends readonly [infer Head, ...infer Tail]
+    ? readonly [StrictReactNode<Head>, ...StrictTuple<Tail>]
+    : readonly [];
+
+export type StrictReactNode<T> = T extends string
+    ? StrictStaticString<T>
+    : T extends readonly [infer Head, ...infer Tail]
+        ? readonly [StrictReactNode<Head>, ...StrictTuple<Tail>]
+        : T extends readonly (infer U)[]
+            ? readonly StrictReactNode<U>[]
+            : Exclude<T, string>;
+
 export function buildMessageFromChildren(children: ReactNode): {
     id: string;
     values: ReactNode[];

--- a/react/test/components.test.ts
+++ b/react/test/components.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import React, { createElement, Fragment } from "react";
+import type { GetTextTranslations } from "gettext-parser";
+
+const translations: GetTextTranslations = { charset: "utf-8", headers: {}, translations: { "": {} } };
+import { renderToString } from "react-dom/server";
+import { Message, Plural, TranslationsProvider } from "../src/index.ts";
+
+test("Message renders interpolated children", () => {
+    const output = renderToString(
+        createElement(
+            TranslationsProvider,
+            { locale: "en", translations: { en: translations } },
+            createElement(
+                Message,
+                null,
+                "Hello ",
+                createElement("b", null, "World"),
+                "!",
+            ),
+        ),
+    );
+    assert.equal(output, "Hello <b>World</b>!");
+});
+
+test("Plural selects plural form", () => {
+    const forms = [
+        createElement(Fragment, null, "One ", createElement("b", null, "item")),
+        createElement(Fragment, null, "Many ", createElement("i", null, "items")),
+    ] as const;
+    const output = renderToString(
+        createElement(
+            TranslationsProvider,
+            { locale: "en", translations: { en: translations } },
+            createElement(Plural, { number: 2, forms }),
+        ),
+    );
+    assert.equal(output, "Many <i>items</i>");
+});

--- a/react/test/utils.test.ts
+++ b/react/test/utils.test.ts
@@ -1,0 +1,11 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { createElement } from "react";
+import { buildMessageFromChildren } from "../src/utils.ts";
+
+test("buildMessageFromChildren splits id and values", () => {
+    const child = createElement("b", null, "world");
+    const { id, values } = buildMessageFromChildren(["Hello ", child, "!"]);
+    assert.equal(id, "Hello ${0}!");
+    assert.equal(values.length, 1);
+});


### PR DESCRIPTION
## Summary
- refine React translation components with stricter static string enforcement
- expose `StrictReactNode` helper for reusable React node typing
- add unit tests for message utilities and translation components

## Testing
- `npm run typecheck --workspace react`
- `npm test --workspace react`
- `npm run check --workspace react` *(fails: Cannot find module '@biomejs/cli-linux-x64/biome')*

------
https://chatgpt.com/codex/tasks/task_e_68baf10f665c832fad709e81515113aa