### PR TITLE
chore: add tsdown build and release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  release:
+    types: [published]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - run: npm test
+
+  publish:
+    if: github.event_name == 'release'
+    needs: test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        registry: [github]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: ${{ matrix.registry == 'github' && 'https://npm.pkg.github.com' || 'https://registry.npmjs.org' }}
+          scope: '@let-value'
+      - run: npm ci
+      - run: npm run build
+      - run: npm publish --workspaces
+        env:
+          NODE_AUTH_TOKEN: ${{ matrix.registry == 'github' && secrets.GITHUB_TOKEN || secrets.NPM_TOKEN }}

--- a/extract/bin/cli.ts
+++ b/extract/bin/cli.ts
@@ -1,16 +1,20 @@
-#!/usr/bin/env -S node --experimental-strip-types
+#!/usr/bin/env node
 import fs from "node:fs";
 import { extractPo } from "../src/index.ts";
 
-const [, , entry, locale = "en", out] = process.argv;
-if (!entry) {
-    console.error("Usage: translate-extract <entry> [locale] [out]");
-    process.exit(1);
+async function main() {
+    const [, , entry, locale = "en", out] = process.argv;
+    if (!entry) {
+        console.error("Usage: translate-extract <entry> [locale] [out]");
+        process.exit(1);
+    }
+
+    const po = await extractPo(entry, locale);
+    if (out) {
+        fs.writeFileSync(out, po);
+    } else {
+        process.stdout.write(po);
+    }
 }
 
-const po = await extractPo(entry, locale);
-if (out) {
-    fs.writeFileSync(out, po);
-} else {
-    process.stdout.write(po);
-}
+void main();

--- a/extract/package.json
+++ b/extract/package.json
@@ -2,10 +2,23 @@
     "name": "@let-value/translate-extract",
     "version": "1.0.0",
     "type": "module",
-    "main": "src/index.ts",
+    "main": "dist/index.cjs",
+    "module": "dist/index.js",
+    "types": "dist/index.d.ts",
     "bin": {
-        "translate-extract": "bin/cli.ts"
+        "translate-extract": "dist/bin/cli.js"
     },
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "import": "./dist/index.js",
+            "require": "./dist/index.cjs"
+        },
+        "./package.json": "./package.json"
+    },
+    "files": [
+        "dist"
+    ],
     "dependencies": {
         "@let-value/translate": "^1.0.0",
         "gettext-parser": "8.0.0",
@@ -19,12 +32,16 @@
     },
     "devDependencies": {
         "@types/gettext-parser": "8.0.0",
+        "tsdown": "0.14.2",
         "typescript": "5.9.2"
     },
     "scripts": {
-        "build": "echo building extract",
+        "build": "tsdown src/index.ts bin/cli.ts --format esm,cjs --dts --out-dir dist --clean",
         "check": "biome check .",
         "typecheck": "tsc --build",
         "test": "node --test \"**/*.test.ts\""
+    },
+    "publishConfig": {
+        "registry": "https://npm.pkg.github.com"
     }
 }

--- a/loader/package.json
+++ b/loader/package.json
@@ -3,42 +3,42 @@
     "version": "1.0.0",
     "type": "module",
     "main": "dist/index.cjs",
-    "module": "dist/index.mjs",
+    "module": "dist/index.js",
     "types": "dist/index.d.ts",
     "exports": {
         ".": {
             "types": "./dist/index.d.ts",
-            "import": "./dist/index.mjs",
+            "import": "./dist/index.js",
             "require": "./dist/index.cjs"
         },
         "./bun": {
             "types": "./dist/bun.d.ts",
-            "import": "./dist/bun.mjs",
+            "import": "./dist/bun.js",
             "require": "./dist/bun.cjs"
         },
         "./rollup": {
             "types": "./dist/rollup.d.ts",
-            "import": "./dist/rollup.mjs",
+            "import": "./dist/rollup.js",
             "require": "./dist/rollup.cjs"
         },
         "./vite": {
             "types": "./dist/vite.d.ts",
-            "import": "./dist/vite.mjs",
+            "import": "./dist/vite.js",
             "require": "./dist/vite.cjs"
         },
         "./webpack": {
             "types": "./dist/webpack.d.ts",
-            "import": "./dist/webpack.mjs",
+            "import": "./dist/webpack.js",
             "require": "./dist/webpack.cjs"
         },
         "./esbuild": {
             "types": "./dist/esbuild.d.ts",
-            "import": "./dist/esbuild.mjs",
+            "import": "./dist/esbuild.js",
             "require": "./dist/esbuild.cjs"
         },
         "./rspack": {
             "types": "./dist/rspack.d.ts",
-            "import": "./dist/rspack.mjs",
+            "import": "./dist/rspack.js",
             "require": "./dist/rspack.cjs"
         },
         "./package.json": "./package.json"
@@ -63,6 +63,9 @@
         "check": "biome check .",
         "typecheck": "tsc --build",
         "test": "node --test \"**/*.test.ts\""
+    },
+    "publishConfig": {
+        "registry": "https://npm.pkg.github.com"
     },
     "peerDependencies": {
         "@types/bun": "1.2.21"

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,9 @@
             ],
             "devDependencies": {
                 "@biomejs/biome": "2.2.2",
+                "@biomejs/cli-linux-x64": "2.2.3",
+                "@rolldown/binding-linux-x64-gnu": "1.0.0-beta.35",
+                "bumpp": "10.2.3",
                 "typescript": "5.9.2"
             },
             "engines": {
@@ -36,10 +39,11 @@
                 "tree-sitter-typescript": "0.23.2"
             },
             "bin": {
-                "translate-extract": "bin/cli.ts"
+                "translate-extract": "dist/bin/cli.js"
             },
             "devDependencies": {
                 "@types/gettext-parser": "8.0.0",
+                "tsdown": "0.14.2",
                 "typescript": "5.9.2"
             }
         },
@@ -223,6 +227,141 @@
                 "@biomejs/cli-win32-x64": "2.2.2"
             }
         },
+        "node_modules/@biomejs/biome/node_modules/@biomejs/cli-linux-x64": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.2.2.tgz",
+            "integrity": "sha512-Ogb+77edO5LEP/xbNicACOWVLt8mgC+E1wmpUakr+O4nKwLt9vXe74YNuT3T1dUBxC/SnrVmlzZFC7kQJEfquQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT OR Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.21.3"
+            }
+        },
+        "node_modules/@biomejs/cli-darwin-arm64": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.2.2.tgz",
+            "integrity": "sha512-6ePfbCeCPryWu0CXlzsWNZgVz/kBEvHiPyNpmViSt6A2eoDf4kXs3YnwQPzGjy8oBgQulrHcLnJL0nkCh80mlQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT OR Apache-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=14.21.3"
+            }
+        },
+        "node_modules/@biomejs/cli-darwin-x64": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.2.2.tgz",
+            "integrity": "sha512-Tn4JmVO+rXsbRslml7FvKaNrlgUeJot++FkvYIhl1OkslVCofAtS35MPlBMhXgKWF9RNr9cwHanrPTUUXcYGag==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT OR Apache-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=14.21.3"
+            }
+        },
+        "node_modules/@biomejs/cli-linux-arm64": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.2.2.tgz",
+            "integrity": "sha512-JfrK3gdmWWTh2J5tq/rcWCOsImVyzUnOS2fkjhiYKCQ+v8PqM+du5cfB7G1kXas+7KQeKSWALv18iQqdtIMvzw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT OR Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.21.3"
+            }
+        },
+        "node_modules/@biomejs/cli-linux-arm64-musl": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.2.2.tgz",
+            "integrity": "sha512-/MhYg+Bd6renn6i1ylGFL5snYUn/Ct7zoGVKhxnro3bwekiZYE8Kl39BSb0MeuqM+72sThkQv4TnNubU9njQRw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT OR Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.21.3"
+            }
+        },
+        "node_modules/@biomejs/cli-linux-x64": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.2.3.tgz",
+            "integrity": "sha512-LEtyYL1fJsvw35CxrbQ0gZoxOG3oZsAjzfRdvRBRHxOpQ91Q5doRVjvWW/wepgSdgk5hlaNzfeqpyGmfSD0Eyw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT OR Apache-2.0",
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.21.3"
+            }
+        },
+        "node_modules/@biomejs/cli-linux-x64-musl": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.2.2.tgz",
+            "integrity": "sha512-ZCLXcZvjZKSiRY/cFANKg+z6Fhsf9MHOzj+NrDQcM+LbqYRT97LyCLWy2AS+W2vP+i89RyRM+kbGpUzbRTYWig==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT OR Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=14.21.3"
+            }
+        },
+        "node_modules/@biomejs/cli-win32-arm64": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.2.2.tgz",
+            "integrity": "sha512-wBe2wItayw1zvtXysmHJQoQqXlTzHSpQRyPpJKiNIR21HzH/CrZRDFic1C1jDdp+zAPtqhNExa0owKMbNwW9cQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT OR Apache-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=14.21.3"
+            }
+        },
         "node_modules/@biomejs/cli-win32-x64": {
             "version": "2.2.2",
             "cpu": [
@@ -236,6 +375,40 @@
             ],
             "engines": {
                 "node": ">=14.21.3"
+            }
+        },
+        "node_modules/@emnapi/core": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.5.0.tgz",
+            "integrity": "sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.1.0",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/runtime": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.5.0.tgz",
+            "integrity": "sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/wasi-threads": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
+            "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
             }
         },
         "node_modules/@isaacs/balanced-match": {
@@ -331,6 +504,19 @@
             "resolved": "react",
             "link": true
         },
+        "node_modules/@napi-rs/wasm-runtime": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.0.3.tgz",
+            "integrity": "sha512-rZxtMsLwjdXkMUGC3WwsPwLNVqVqnTJT6MNIB6e+5fhMcSCPP0AOsNWuMQ5mdCq6HNjs/ZeWAEchpqeprqBD2Q==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/core": "^1.4.5",
+                "@emnapi/runtime": "^1.4.5",
+                "@tybys/wasm-util": "^0.10.0"
+            }
+        },
         "node_modules/@oxc-project/runtime": {
             "version": "0.82.3",
             "resolved": "https://registry.npmjs.org/@oxc-project/runtime/-/runtime-0.82.3.tgz",
@@ -385,6 +571,190 @@
                 "url": "https://github.com/sponsors/sxzz"
             }
         },
+        "node_modules/@rolldown/binding-android-arm64": {
+            "version": "1.0.0-beta.34",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-beta.34.tgz",
+            "integrity": "sha512-jf5GNe5jP3Sr1Tih0WKvg2bzvh5T/1TA0fn1u32xSH7ca/p5t+/QRr4VRFCV/na5vjwKEhwWrChsL2AWlY+eoA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@rolldown/binding-darwin-arm64": {
+            "version": "1.0.0-beta.34",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-beta.34.tgz",
+            "integrity": "sha512-2F/TqH4QuJQ34tgWxqBjFL3XV1gMzeQgUO8YRtCPGBSP0GhxtoFzsp7KqmQEothsxztlv+KhhT9Dbg3HHwHViQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rolldown/binding-darwin-x64": {
+            "version": "1.0.0-beta.34",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-beta.34.tgz",
+            "integrity": "sha512-E1QuFslgLWbHQ8Qli/AqUKdfg0pockQPwRxVbhNQ74SciZEZpzLaujkdmOLSccMlSXDfFCF8RPnMoRAzQ9JV8Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@rolldown/binding-freebsd-x64": {
+            "version": "1.0.0-beta.34",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-beta.34.tgz",
+            "integrity": "sha512-VS8VInNCwnkpI9WeQaWu3kVBq9ty6g7KrHdLxYMzeqz24+w9hg712TcWdqzdY6sn+24lUoMD9jTZrZ/qfVpk0g==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+            "version": "1.0.0-beta.34",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-beta.34.tgz",
+            "integrity": "sha512-4St4emjcnULnxJYb/5ZDrH/kK/j6PcUgc3eAqH5STmTrcF+I9m/X2xvSF2a2bWv1DOQhxBewThu0KkwGHdgu5w==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rolldown/binding-linux-arm64-gnu": {
+            "version": "1.0.0-beta.34",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-beta.34.tgz",
+            "integrity": "sha512-a737FTqhFUoWfnebS2SnQ2BS50p0JdukdkUBwy2J06j4hZ6Eej0zEB8vTfAqoCjn8BQKkXBy+3Sx0IRkgwz1gA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rolldown/binding-linux-arm64-musl": {
+            "version": "1.0.0-beta.34",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-beta.34.tgz",
+            "integrity": "sha512-NH+FeQWKyuw0k+PbXqpFWNfvD8RPvfJk766B/njdaWz4TmiEcSB0Nb6guNw1rBpM1FmltQYb3fFnTumtC6pRfA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rolldown/binding-linux-x64-gnu": {
+            "version": "1.0.0-beta.35",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-beta.35.tgz",
+            "integrity": "sha512-1r1Ac/vTcm1q4kRiX/NB6qtorF95PhjdCxKH3Z5pb+bWMDZnmcz18fzFlT/3C6Qpj/ZqUF+EUrG4QEDXtVXGgg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rolldown/binding-linux-x64-musl": {
+            "version": "1.0.0-beta.34",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-beta.34.tgz",
+            "integrity": "sha512-wDd/HrNcVoBhWWBUW3evJHoo7GJE/RofssBy3Dsiip05YUBmokQVrYAyrboOY4dzs/lJ7HYeBtWQ9hj8wlyF0A==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rolldown/binding-openharmony-arm64": {
+            "version": "1.0.0-beta.34",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-beta.34.tgz",
+            "integrity": "sha512-dH3FTEV6KTNWpYSgjSXZzeX7vLty9oBYn6R3laEdhwZftQwq030LKL+5wyQdlbX5pnbh4h127hpv3Hl1+sj8dg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ]
+        },
+        "node_modules/@rolldown/binding-wasm32-wasi": {
+            "version": "1.0.0-beta.34",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-beta.34.tgz",
+            "integrity": "sha512-y5BUf+QtO0JsIDKA51FcGwvhJmv89BYjUl8AmN7jqD6k/eU55mH6RJYnxwCsODq5m7KSSTigVb6O7/GqB8wbPw==",
+            "cpu": [
+                "wasm32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@napi-rs/wasm-runtime": "^1.0.3"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@rolldown/binding-win32-arm64-msvc": {
+            "version": "1.0.0-beta.34",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-beta.34.tgz",
+            "integrity": "sha512-ga5hFhdTwpaNxEiuxZHWnD3ed0GBAzbgzS5tRHpe0ObptxM1a9Xrq6TVfNQirBLwb5Y7T/FJmJi3pmdLy95ljg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@rolldown/binding-win32-ia32-msvc": {
+            "version": "1.0.0-beta.34",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.0.0-beta.34.tgz",
+            "integrity": "sha512-4/MBp9T9eRnZskxWr8EXD/xHvLhdjWaeX/qY9LPRG1JdCGV3DphkLTy5AWwIQ5jhAy2ZNJR5z2fYRlpWU0sIyQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
         "node_modules/@rolldown/binding-win32-x64-msvc": {
             "version": "1.0.0-beta.34",
             "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-beta.34.tgz",
@@ -405,6 +775,17 @@
             "integrity": "sha512-LyAREkZHP5pMom7c24meKmJCdhf2hEyvam2q0unr3or9ydwDL+DJ8chTF6Av/RFPb3rH8UFBdMzO5MxTZW97oA==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@tybys/wasm-util": {
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.0.tgz",
+            "integrity": "sha512-VyyPYFlOMNylG45GoAe0xDoLwWuowvf92F9kySqzYh8vmYm7D2u4iUJKa1tOUpS70Ku13ASrOkS4ScXFsTaCNQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
         },
         "node_modules/@types/bun": {
             "version": "1.2.21",
@@ -511,6 +892,13 @@
                 "node": ">=14"
             }
         },
+        "node_modules/args-tokenizer": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/args-tokenizer/-/args-tokenizer-0.3.0.tgz",
+            "integrity": "sha512-xXAd7G2Mll5W8uo37GETpQ2VrE84M181Z7ugHFGQnJZ50M2mbOv0osSZ9VsSgPfJQ+LVG0prSi0th+ELMsno7Q==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/ast-kit": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ast-kit/-/ast-kit-2.1.2.tgz",
@@ -593,6 +981,32 @@
                 "ieee754": "^1.2.1"
             }
         },
+        "node_modules/bumpp": {
+            "version": "10.2.3",
+            "resolved": "https://registry.npmjs.org/bumpp/-/bumpp-10.2.3.tgz",
+            "integrity": "sha512-nsFBZACxuBVu6yzDSaZZaWpX5hTQ+++9WtYkmO+0Bd3cpSq0Mzvqw5V83n+fOyRj3dYuZRFCQf5Z9NNfZj+Rnw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansis": "^4.1.0",
+                "args-tokenizer": "^0.3.0",
+                "c12": "^3.2.0",
+                "cac": "^6.7.14",
+                "escalade": "^3.2.0",
+                "jsonc-parser": "^3.3.1",
+                "package-manager-detector": "^1.3.0",
+                "semver": "^7.7.2",
+                "tinyexec": "^1.0.1",
+                "tinyglobby": "^0.2.14",
+                "yaml": "^2.8.1"
+            },
+            "bin": {
+                "bumpp": "bin/bumpp.mjs"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/bun-types": {
             "version": "1.2.21",
             "resolved": "https://registry.npmjs.org/bun-types/-/bun-types-1.2.21.tgz",
@@ -604,6 +1018,35 @@
             },
             "peerDependencies": {
                 "@types/react": "^19"
+            }
+        },
+        "node_modules/c12": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/c12/-/c12-3.2.0.tgz",
+            "integrity": "sha512-ixkEtbYafL56E6HiFuonMm1ZjoKtIo7TH68/uiEq4DAwv9NcUX2nJ95F8TrbMeNjqIkZpruo3ojXQJ+MGG5gcQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chokidar": "^4.0.3",
+                "confbox": "^0.2.2",
+                "defu": "^6.1.4",
+                "dotenv": "^17.2.1",
+                "exsolve": "^1.0.7",
+                "giget": "^2.0.0",
+                "jiti": "^2.5.1",
+                "ohash": "^2.0.11",
+                "pathe": "^2.0.3",
+                "perfect-debounce": "^1.0.0",
+                "pkg-types": "^2.2.0",
+                "rc9": "^2.1.2"
+            },
+            "peerDependencies": {
+                "magicast": "^0.3.5"
+            },
+            "peerDependenciesMeta": {
+                "magicast": {
+                    "optional": true
+                }
             }
         },
         "node_modules/cac": {
@@ -632,6 +1075,16 @@
                 "url": "https://paulmillr.com/funding/"
             }
         },
+        "node_modules/citty": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
+            "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "consola": "^3.2.3"
+            }
+        },
         "node_modules/color-convert": {
             "version": "2.0.1",
             "license": "MIT",
@@ -645,6 +1098,23 @@
         "node_modules/color-name": {
             "version": "1.1.4",
             "license": "MIT"
+        },
+        "node_modules/confbox": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz",
+            "integrity": "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/consola": {
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+            "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^14.18.0 || >=16.10.0"
+            }
         },
         "node_modules/content-type": {
             "version": "1.0.5",
@@ -696,6 +1166,13 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/destr": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
+            "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/diff": {
             "version": "8.0.2",
             "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.2.tgz",
@@ -704,6 +1181,19 @@
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.3.1"
+            }
+        },
+        "node_modules/dotenv": {
+            "version": "17.2.2",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.2.tgz",
+            "integrity": "sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://dotenvx.com"
             }
         },
         "node_modules/dts-resolver": {
@@ -752,6 +1242,16 @@
                 "iconv-lite": "^0.6.2"
             }
         },
+        "node_modules/escalade": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+            "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/event-target-shim": {
             "version": "5.0.1",
             "license": "MIT",
@@ -765,6 +1265,13 @@
             "engines": {
                 "node": ">=0.8.x"
             }
+        },
+        "node_modules/exsolve": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.7.tgz",
+            "integrity": "sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/fdir": {
             "version": "6.5.0",
@@ -822,6 +1329,24 @@
             },
             "engines": {
                 "node": ">=18"
+            }
+        },
+        "node_modules/giget": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/giget/-/giget-2.0.0.tgz",
+            "integrity": "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "citty": "^0.1.6",
+                "consola": "^3.4.0",
+                "defu": "^6.1.4",
+                "node-fetch-native": "^1.6.6",
+                "nypm": "^0.6.0",
+                "pathe": "^2.0.3"
+            },
+            "bin": {
+                "giget": "dist/cli.mjs"
             }
         },
         "node_modules/glob": {
@@ -927,6 +1452,13 @@
                 "node": ">=6"
             }
         },
+        "node_modules/jsonc-parser": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+            "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/lru-cache": {
             "version": "11.1.0",
             "license": "ISC",
@@ -981,6 +1513,13 @@
                 "node": "^18 || ^20 || >= 21"
             }
         },
+        "node_modules/node-fetch-native": {
+            "version": "1.6.7",
+            "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+            "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/node-gyp-build": {
             "version": "4.8.4",
             "license": "MIT",
@@ -989,6 +1528,33 @@
                 "node-gyp-build-optional": "optional.js",
                 "node-gyp-build-test": "build-test.js"
             }
+        },
+        "node_modules/nypm": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.1.tgz",
+            "integrity": "sha512-hlacBiRiv1k9hZFiphPUkfSQ/ZfQzZDzC+8z0wL3lvDAOUu/2NnChkKuMoMjNur/9OpKuz2QsIeiPVN0xM5Q0w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "citty": "^0.1.6",
+                "consola": "^3.4.2",
+                "pathe": "^2.0.3",
+                "pkg-types": "^2.2.0",
+                "tinyexec": "^1.0.1"
+            },
+            "bin": {
+                "nypm": "dist/cli.mjs"
+            },
+            "engines": {
+                "node": "^14.16.0 || >=16.10.0"
+            }
+        },
+        "node_modules/ohash": {
+            "version": "2.0.11",
+            "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+            "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/oxc-resolver": {
             "version": "11.7.1",
@@ -1026,6 +1592,13 @@
             "version": "1.0.1",
             "license": "BlueOak-1.0.0"
         },
+        "node_modules/package-manager-detector": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.3.0.tgz",
+            "integrity": "sha512-ZsEbbZORsyHuO00lY1kV3/t72yp6Ysay6Pd17ZAlNGuGwmWDLCJxFpRs0IzfXfj1o4icJOkUEioexFHzyPurSQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/path-key": {
             "version": "3.1.1",
             "license": "MIT",
@@ -1054,6 +1627,13 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/perfect-debounce": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+            "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/picomatch": {
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
@@ -1064,6 +1644,18 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/pkg-types": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
+            "integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "confbox": "^0.2.2",
+                "exsolve": "^1.0.7",
+                "pathe": "^2.0.3"
             }
         },
         "node_modules/plural-forms": {
@@ -1101,6 +1693,17 @@
             "license": "MIT",
             "engines": {
                 "node": ">=14.18.0"
+            }
+        },
+        "node_modules/rc9": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
+            "integrity": "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "defu": "^6.1.4",
+                "destr": "^2.0.3"
             }
         },
         "node_modules/react": {
@@ -1235,6 +1838,20 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/rolldown/node_modules/@rolldown/binding-linux-x64-gnu": {
+            "version": "1.0.0-beta.34",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-beta.34.tgz",
+            "integrity": "sha512-Q3RSCivp8pNadYK8ke3hLnQk08BkpZX9BmMjgwae2FWzdxhxxUiUzd9By7kneUL0vRQ4uRnhD9VkFQ+Haeqdvw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
         },
         "node_modules/safe-buffer": {
             "version": "5.2.1",
@@ -1392,6 +2009,13 @@
                 "node": ">=8"
             }
         },
+        "node_modules/tinyexec": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.1.tgz",
+            "integrity": "sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/tinyglobby": {
             "version": "0.2.14",
             "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
@@ -1519,12 +2143,13 @@
                 }
             }
         },
-        "node_modules/tsdown/node_modules/tinyexec": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.1.tgz",
-            "integrity": "sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==",
+        "node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
             "dev": true,
-            "license": "MIT"
+            "license": "0BSD",
+            "optional": true
         },
         "node_modules/typescript": {
             "version": "5.9.2",
@@ -1669,6 +2294,19 @@
                 "node": ">=8"
             }
         },
+        "node_modules/yaml": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+            "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "yaml": "bin.mjs"
+            },
+            "engines": {
+                "node": ">= 14.6"
+            }
+        },
         "react": {
             "name": "@let-value/translate-react",
             "version": "1.0.0",
@@ -1682,6 +2320,7 @@
                 "@types/react-dom": "19.1.9",
                 "react": "19.1.1",
                 "react-dom": "19.1.1",
+                "tsdown": "0.14.2",
                 "typescript": "5.9.2"
             },
             "peerDependencies": {
@@ -1697,6 +2336,7 @@
             },
             "devDependencies": {
                 "@types/gettext-parser": "8.0.0",
+                "tsdown": "0.14.2",
                 "typescript": "5.9.2"
             }
         }

--- a/package.json
+++ b/package.json
@@ -16,14 +16,21 @@
         "build": "npm run build --workspaces",
         "check": "npm run check --workspaces",
         "typecheck": "npm run typecheck --workspaces",
-        "test": "npm run test --workspaces"
+        "test": "npm run test --workspaces",
+        "release": "bumpp package.json loader/package.json translate/package.json extract/package.json react/package.json",
+        "publish": "npm publish --workspaces"
     },
     "devDependencies": {
         "@biomejs/biome": "2.2.2",
+        "@biomejs/cli-linux-x64": "2.2.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-beta.35",
+        "bumpp": "10.2.3",
         "typescript": "5.9.2"
     },
     "trustedDependencies": [
         "oxc-resolver",
-        "tree-sitter-javascript"
+        "tree-sitter-javascript",
+        "@rolldown/binding-linux-x64-gnu",
+        "@biomejs/cli-linux-x64"
     ]
 }

--- a/react/package.json
+++ b/react/package.json
@@ -2,12 +2,22 @@
     "name": "@let-value/translate-react",
     "version": "1.0.0",
     "type": "module",
-    "main": "src/index.ts",
+    "main": "dist/index.cjs",
+    "module": "dist/index.js",
+    "types": "dist/index.d.ts",
     "exports": {
-        ".": "./src/index.ts"
+        ".": {
+            "types": "./dist/index.d.ts",
+            "import": "./dist/index.js",
+            "require": "./dist/index.cjs"
+        },
+        "./package.json": "./package.json"
     },
+    "files": [
+        "dist"
+    ],
     "scripts": {
-        "build": "echo building translate-react",
+        "build": "tsdown src/index.ts --format esm,cjs --dts --out-dir dist --clean",
         "check": "biome check .",
         "typecheck": "tsc --build",
         "test": "node --test"
@@ -22,9 +32,13 @@
         "@types/react-dom": "19.1.9",
         "react": "19.1.1",
         "react-dom": "19.1.1",
+        "tsdown": "0.14.2",
         "typescript": "5.9.2"
     },
     "peerDependencies": {
         "react": ">=19"
+    },
+    "publishConfig": {
+        "registry": "https://npm.pkg.github.com"
     }
 }

--- a/translate/package.json
+++ b/translate/package.json
@@ -2,12 +2,22 @@
     "name": "@let-value/translate",
     "version": "1.0.0",
     "type": "module",
-    "main": "src/index.ts",
+    "main": "dist/index.cjs",
+    "module": "dist/index.js",
+    "types": "dist/index.d.ts",
     "exports": {
-        ".": "./src/index.ts"
+        ".": {
+            "types": "./dist/index.d.ts",
+            "import": "./dist/index.js",
+            "require": "./dist/index.cjs"
+        },
+        "./package.json": "./package.json"
     },
+    "files": [
+        "dist"
+    ],
     "scripts": {
-        "build": "echo building translate",
+        "build": "tsdown src/index.ts --format esm,cjs --dts --out-dir dist --clean",
         "check": "biome check .",
         "typecheck": "tsc --build",
         "test": "node --test"
@@ -18,6 +28,10 @@
     },
     "devDependencies": {
         "@types/gettext-parser": "8.0.0",
+        "tsdown": "0.14.2",
         "typescript": "5.9.2"
+    },
+    "publishConfig": {
+        "registry": "https://npm.pkg.github.com"
     }
 }


### PR DESCRIPTION
## Summary
- add tsdown-based builds for packages and prepare for publishing to GitHub Packages
- add release scripts using bumpp and publish skeleton for future registries
- add GitHub Actions workflow to test, build and publish

## Testing
- `npm run build`
- `npm test`
- `npm run check` *(fails: Formatter would have printed the following content)*


------
https://chatgpt.com/codex/tasks/task_e_68bbe953f020832f8bb7d500df356a3c