### PR TITLE
feat(loader): expose types for .po static files

### DIFF
--- a/loader/package.json
+++ b/loader/package.json
@@ -41,6 +41,9 @@
             "import": "./dist/rspack.js",
             "require": "./dist/rspack.cjs"
         },
+        "./po": {
+            "types": "./dist/po.d.ts"
+        },
         "./package.json": "./package.json"
     },
     "files": [
@@ -59,7 +62,7 @@
         "typescript": "5.9.2"
     },
     "scripts": {
-        "build": "tsdown src/index.ts src/rollup.ts src/vite.ts src/webpack.ts src/esbuild.ts src/rspack.ts src/bun.ts --format esm,cjs --dts --out-dir dist --clean",
+        "build": "tsdown src/index.ts src/rollup.ts src/vite.ts src/webpack.ts src/esbuild.ts src/rspack.ts src/bun.ts --format esm,cjs --dts --out-dir dist --clean && cp src/po.d.ts dist/po.d.ts",
         "check": "biome check .",
         "typecheck": "tsc --build",
         "test": "node --test \"**/*.test.ts\""

--- a/loader/src/po.d.ts
+++ b/loader/src/po.d.ts
@@ -1,0 +1,4 @@
+declare module "*.po" {
+    const content: import("gettext-parser").GetTextTranslations;
+    export default content;
+}


### PR DESCRIPTION
## Summary
- add ambient declaration for importing `.po` files as `GetTextTranslations`
- export new `./po` entry and copy declaration during build

## Testing
- `npm run build --workspace loader`
- `npm test --workspace loader`
- `npm run check --workspace loader`
- `npm run typecheck --workspace loader`


------
https://chatgpt.com/codex/tasks/task_e_68bc12afc3c4832fae892b03b5e5a9ee