### PR TITLE
test: update expected message format

### DIFF
--- a/extract/src/plugins/core/queries/tests/context-plural.test.ts
+++ b/extract/src/plugins/core/queries/tests/context-plural.test.ts
@@ -19,19 +19,19 @@ suite("should extract context builder plural messages", () =>
                     {
                         error: undefined,
                         translation: {
-                            msgctxt: "ctx",
-                            msgid: "hello",
-                            msgid_plural: "hellos",
-                            msgstr: ["hello", "hellos"],
+                            context: "ctx",
+                            id: "hello",
+                            plural: "hellos",
+                            message: ["hello", "hellos"],
                         },
                     },
                     {
                         error: undefined,
                         translation: {
-                            msgctxt: "company",
-                            msgid: "${count} apple",
-                            msgid_plural: "${count} apples",
-                            msgstr: ["${count} apple", "${count} apples"],
+                            context: "company",
+                            id: "${count} apple",
+                            plural: "${count} apples",
+                            message: ["${count} apple", "${count} apples"],
                             comments: {
                                 extracted: "comment",
                             },
@@ -40,19 +40,19 @@ suite("should extract context builder plural messages", () =>
                     {
                         error: undefined,
                         translation: {
-                            msgctxt: "ctx",
-                            msgid: "greeting",
-                            msgid_plural: "greetings",
-                            msgstr: ["Hello, world!", "Hello, worlds!"],
+                            context: "ctx",
+                            id: "greeting",
+                            plural: "greetings",
+                            message: ["Hello, world!", "Hello, worlds!"],
                         },
                     },
                     {
                         error: undefined,
                         translation: {
-                            msgctxt: "ctx",
-                            msgid: "Hello, ${name}!",
-                            msgid_plural: "Hello, ${name}!",
-                            msgstr: ["Hello, ${name}!", "Hello, ${name}!"],
+                            context: "ctx",
+                            id: "Hello, ${name}!",
+                            plural: "Hello, ${name}!",
+                            message: ["Hello, ${name}!", "Hello, ${name}!"],
                         },
                     },
                     {

--- a/extract/src/plugins/core/queries/tests/context.test.ts
+++ b/extract/src/plugins/core/queries/tests/context.test.ts
@@ -19,16 +19,16 @@ suite("should extract context builder messages", () =>
                         error: undefined,
                         translation: {
                             msgctxt: "ctx",
-                            msgid: "hello",
-                            msgstr: ["hello"],
+                            id: "hello",
+                            message: ["hello"],
                         },
                     },
                     {
                         error: undefined,
                         translation: {
                             msgctxt: "ctx",
-                            msgid: "hello comment",
-                            msgstr: ["hello comment"],
+                            id: "hello comment",
+                            message: ["hello comment"],
                             comments: {
                                 extracted: "comment",
                             },
@@ -38,8 +38,8 @@ suite("should extract context builder messages", () =>
                         error: undefined,
                         translation: {
                             msgctxt: "ctx",
-                            msgid: "greeting",
-                            msgstr: ["Hello, world!"],
+                            id: "greeting",
+                            message: ["Hello, world!"],
                             comments: {
                                 extracted: "descriptor",
                             },
@@ -49,8 +49,8 @@ suite("should extract context builder messages", () =>
                         error: undefined,
                         translation: {
                             msgctxt: "ctx",
-                            msgid: "greeting",
-                            msgstr: ["Hello, world!"],
+                            id: "greeting",
+                            message: ["Hello, world!"],
                             comments: {
                                 extracted: "multiline\ncomment",
                             },
@@ -60,8 +60,8 @@ suite("should extract context builder messages", () =>
                         error: undefined,
                         translation: {
                             msgctxt: "ctx",
-                            msgid: "Hello, ${name}!",
-                            msgstr: ["Hello, ${name}!"],
+                            id: "Hello, ${name}!",
+                            message: ["Hello, ${name}!"],
                         },
                     },
                     {

--- a/extract/src/plugins/core/queries/tests/gettext.test.ts
+++ b/extract/src/plugins/core/queries/tests/gettext.test.ts
@@ -24,15 +24,15 @@ suite("should extract messages", () =>
                     {
                         error: undefined,
                         translation: {
-                            msgid: "hello",
-                            msgstr: ["hello"],
+                            id: "hello",
+                            message: ["hello"],
                         },
                     },
                     {
                         error: undefined,
                         translation: {
-                            msgid: "hello comment",
-                            msgstr: ["hello comment"],
+                            id: "hello comment",
+                            message: ["hello comment"],
                             comments: {
                                 extracted: "comment",
                             },
@@ -41,8 +41,8 @@ suite("should extract messages", () =>
                     {
                         error: undefined,
                         translation: {
-                            msgid: "greeting",
-                            msgstr: ["Hello, world!"],
+                            id: "greeting",
+                            message: ["Hello, world!"],
                             comments: {
                                 extracted: "descriptor",
                             },
@@ -51,8 +51,8 @@ suite("should extract messages", () =>
                     {
                         error: undefined,
                         translation: {
-                            msgid: "greeting",
-                            msgstr: ["Hello, world!"],
+                            id: "greeting",
+                            message: ["Hello, world!"],
                             comments: {
                                 extracted: "multiline\ncomment",
                             },
@@ -61,8 +61,8 @@ suite("should extract messages", () =>
                     {
                         error: undefined,
                         translation: {
-                            msgid: "Hello, ${name}!",
-                            msgstr: ["Hello, ${name}!"],
+                            id: "Hello, ${name}!",
+                            message: ["Hello, ${name}!"],
                         },
                     },
                     {

--- a/extract/src/plugins/core/queries/tests/message.test.ts
+++ b/extract/src/plugins/core/queries/tests/message.test.ts
@@ -19,15 +19,15 @@ suite("should extract messages", () =>
                     {
                         error: undefined,
                         translation: {
-                            msgid: "hello",
-                            msgstr: ["hello"],
+                            id: "hello",
+                            message: ["hello"],
                         },
                     },
                     {
                         error: undefined,
                         translation: {
-                            msgid: "hello comment",
-                            msgstr: ["hello comment"],
+                            id: "hello comment",
+                            message: ["hello comment"],
                             comments: {
                                 extracted: "comment",
                             },
@@ -36,8 +36,8 @@ suite("should extract messages", () =>
                     {
                         error: undefined,
                         translation: {
-                            msgid: "greeting",
-                            msgstr: ["Hello, world!"],
+                            id: "greeting",
+                            message: ["Hello, world!"],
                             comments: {
                                 extracted: "descriptor",
                             },
@@ -46,8 +46,8 @@ suite("should extract messages", () =>
                     {
                         error: undefined,
                         translation: {
-                            msgid: "greeting",
-                            msgstr: ["Hello, world!"],
+                            id: "greeting",
+                            message: ["Hello, world!"],
                             comments: {
                                 extracted: "multiline\ncomment",
                             },
@@ -56,8 +56,8 @@ suite("should extract messages", () =>
                     {
                         error: undefined,
                         translation: {
-                            msgid: "Hello, ${name}!",
-                            msgstr: ["Hello, ${name}!"],
+                            id: "Hello, ${name}!",
+                            message: ["Hello, ${name}!"],
                         },
                     },
                     {
@@ -71,8 +71,8 @@ suite("should extract messages", () =>
                     {
                         error: undefined,
                         translation: {
-                            msgid: "Hi, nested",
-                            msgstr: ["Hi, nested"],
+                            id: "Hi, nested",
+                            message: ["Hi, nested"],
                         },
                     },
                 ],

--- a/extract/src/plugins/core/queries/tests/ngettext.test.ts
+++ b/extract/src/plugins/core/queries/tests/ngettext.test.ts
@@ -20,17 +20,17 @@ suite("should extract plural messages", () =>
                     {
                         error: undefined,
                         translation: {
-                            msgid: "hello",
-                            msgid_plural: "hellos",
-                            msgstr: ["hello", "hellos"],
+                            id: "hello",
+                            plural: "hellos",
+                            message: ["hello", "hellos"],
                         },
                     },
                     {
                         error: undefined,
                         translation: {
-                            msgid: "${count} apple",
-                            msgid_plural: "${count} apples",
-                            msgstr: ["${count} apple", "${count} apples"],
+                            id: "${count} apple",
+                            plural: "${count} apples",
+                            message: ["${count} apple", "${count} apples"],
                             comments: {
                                 extracted: "comment",
                             },
@@ -39,17 +39,17 @@ suite("should extract plural messages", () =>
                     {
                         error: undefined,
                         translation: {
-                            msgid: "greeting",
-                            msgid_plural: "greetings",
-                            msgstr: ["Hello, world!", "Hello, worlds!"],
+                            id: "greeting",
+                            plural: "greetings",
+                            message: ["Hello, world!", "Hello, worlds!"],
                         },
                     },
                     {
                         error: undefined,
                         translation: {
-                            msgid: "Hello, ${name}!",
-                            msgid_plural: "Hello, ${name}!",
-                            msgstr: ["Hello, ${name}!", "Hello, ${name}!"],
+                            id: "Hello, ${name}!",
+                            plural: "Hello, ${name}!",
+                            message: ["Hello, ${name}!", "Hello, ${name}!"],
                         },
                     },
                     {

--- a/extract/src/plugins/core/queries/tests/npgettext.test.ts
+++ b/extract/src/plugins/core/queries/tests/npgettext.test.ts
@@ -19,19 +19,19 @@ suite("should extract context plural messages", () =>
                     {
                         error: undefined,
                         translation: {
-                            msgctxt: "ctx",
-                            msgid: "hello",
-                            msgid_plural: "hellos",
-                            msgstr: ["hello", "hellos"],
+                            context: "ctx",
+                            id: "hello",
+                            plural: "hellos",
+                            message: ["hello", "hellos"],
                         },
                     },
                     {
                         error: undefined,
                         translation: {
-                            msgctxt: "company",
-                            msgid: "${count} apple",
-                            msgid_plural: "${count} apples",
-                            msgstr: ["${count} apple", "${count} apples"],
+                            context: "company",
+                            id: "${count} apple",
+                            plural: "${count} apples",
+                            message: ["${count} apple", "${count} apples"],
                             comments: {
                                 extracted: "comment",
                             },
@@ -40,19 +40,19 @@ suite("should extract context plural messages", () =>
                     {
                         error: undefined,
                         translation: {
-                            msgctxt: "ctx",
-                            msgid: "greeting",
-                            msgid_plural: "greetings",
-                            msgstr: ["Hello, world!", "Hello, worlds!"],
+                            context: "ctx",
+                            id: "greeting",
+                            plural: "greetings",
+                            message: ["Hello, world!", "Hello, worlds!"],
                         },
                     },
                     {
                         error: undefined,
                         translation: {
-                            msgctxt: "ctx",
-                            msgid: "Hello, ${name}!",
-                            msgid_plural: "Hello, ${name}!",
-                            msgstr: ["Hello, ${name}!", "Hello, ${name}!"],
+                            context: "ctx",
+                            id: "Hello, ${name}!",
+                            plural: "Hello, ${name}!",
+                            message: ["Hello, ${name}!", "Hello, ${name}!"],
                         },
                     },
                     {

--- a/extract/src/plugins/core/queries/tests/pgettext.test.ts
+++ b/extract/src/plugins/core/queries/tests/pgettext.test.ts
@@ -19,16 +19,16 @@ suite("should extract context messages", () =>
                         error: undefined,
                         translation: {
                             msgctxt: "ctx",
-                            msgid: "hello",
-                            msgstr: ["hello"],
+                            id: "hello",
+                            message: ["hello"],
                         },
                     },
                     {
                         error: undefined,
                         translation: {
                             msgctxt: "ctx",
-                            msgid: "hello comment",
-                            msgstr: ["hello comment"],
+                            id: "hello comment",
+                            message: ["hello comment"],
                             comments: {
                                 extracted: "comment",
                             },
@@ -38,8 +38,8 @@ suite("should extract context messages", () =>
                         error: undefined,
                         translation: {
                             msgctxt: "ctx",
-                            msgid: "greeting",
-                            msgstr: ["Hello, world!"],
+                            id: "greeting",
+                            message: ["Hello, world!"],
                             comments: {
                                 extracted: "descriptor",
                             },
@@ -49,8 +49,8 @@ suite("should extract context messages", () =>
                         error: undefined,
                         translation: {
                             msgctxt: "ctx",
-                            msgid: "greeting",
-                            msgstr: ["Hello, world!"],
+                            id: "greeting",
+                            message: ["Hello, world!"],
                             comments: {
                                 extracted: "multiline\ncomment",
                             },
@@ -60,8 +60,8 @@ suite("should extract context messages", () =>
                         error: undefined,
                         translation: {
                             msgctxt: "ctx",
-                            msgid: "Hello, ${name}!",
-                            msgstr: ["Hello, ${name}!"],
+                            id: "Hello, ${name}!",
+                            message: ["Hello, ${name}!"],
                         },
                     },
                     {

--- a/extract/src/plugins/core/queries/tests/plural.test.ts
+++ b/extract/src/plugins/core/queries/tests/plural.test.ts
@@ -20,17 +20,17 @@ suite("should extract plural messages", () =>
                     {
                         error: undefined,
                         translation: {
-                            msgid: "hello",
-                            msgid_plural: "hellos",
-                            msgstr: ["hello", "hellos"],
+                            id: "hello",
+                            plural: "hellos",
+                            message: ["hello", "hellos"],
                         },
                     },
                     {
                         error: undefined,
                         translation: {
-                            msgid: "${count} apple",
-                            msgid_plural: "${count} apples",
-                            msgstr: ["${count} apple", "${count} apples"],
+                            id: "${count} apple",
+                            plural: "${count} apples",
+                            message: ["${count} apple", "${count} apples"],
                             comments: {
                                 extracted: "comment",
                             },
@@ -39,17 +39,17 @@ suite("should extract plural messages", () =>
                     {
                         error: undefined,
                         translation: {
-                            msgid: "greeting",
-                            msgid_plural: "greetings",
-                            msgstr: ["Hello, world!", "Hello, worlds!"],
+                            id: "greeting",
+                            plural: "greetings",
+                            message: ["Hello, world!", "Hello, worlds!"],
                         },
                     },
                     {
                         error: undefined,
                         translation: {
-                            msgid: "Hello, ${name}!",
-                            msgid_plural: "Hello, ${name}!",
-                            msgstr: ["Hello, ${name}!", "Hello, ${name}!"],
+                            id: "Hello, ${name}!",
+                            plural: "Hello, ${name}!",
+                            message: ["Hello, ${name}!", "Hello, ${name}!"],
                         },
                     },
                     {

--- a/extract/src/tests/run.test.ts
+++ b/extract/src/tests/run.test.ts
@@ -11,7 +11,7 @@ test("passes collected messages to generate hooks", async () => {
     const path = entrypoint;
     const destination = "messages.po";
     const locale = "en";
-    const translations = [{ msgid: "hello", msgstr: [""] }];
+    const translations = [{ id: "hello", message: [""] }];
 
     let generated: GenerateArgs | undefined;
 


### PR DESCRIPTION
## Summary
- align extraction tests with new translation format using `id`, `message`, and `plural`
- ensure context-aware plural tests use `context` field
- fix run test fixture to match updated message shape

## Testing
- `npm test --workspace @let-value/translate-extract`
- `npm test --workspace @let-value/translate-react`


------
https://chatgpt.com/codex/tasks/task_e_68bc377ec928832fba4e3d03d50dcf53