### PR TITLE
feat: add typed locale configuration

### DIFF
--- a/react/src/components/LocaleProvider.ts
+++ b/react/src/components/LocaleProvider.ts
@@ -1,8 +1,9 @@
+import type { Locale } from "@let-value/translate";
 import { createElement, type ReactNode } from "react";
 import { localeContext } from "../context.ts";
 
 export interface LocaleProviderProps {
-    locale: string;
+    locale: Locale;
     children?: ReactNode;
 }
 

--- a/react/src/components/TranslationsProvider.ts
+++ b/react/src/components/TranslationsProvider.ts
@@ -1,3 +1,4 @@
+import type { Locale } from "@let-value/translate";
 import { Translator } from "@let-value/translate";
 import type { GetTextTranslations } from "gettext-parser";
 import { createElement, type ReactNode, Suspense, use, useMemo } from "react";
@@ -7,7 +8,7 @@ type TranslationLoader = () => Promise<GetTextTranslations>;
 type TranslationEntry = GetTextTranslations | TranslationLoader;
 
 export interface TranslationsProviderProps {
-    translations?: Record<string, TranslationEntry>;
+    translations?: Partial<Record<Locale, TranslationEntry>>;
     children?: ReactNode;
 }
 

--- a/react/src/context.ts
+++ b/react/src/context.ts
@@ -1,5 +1,5 @@
-import type { Translator } from "@let-value/translate";
+import type { Locale, Translator } from "@let-value/translate";
 import { createContext } from "react";
 
-export const localeContext = createContext<string | undefined>(undefined);
+export const localeContext = createContext<Locale | undefined>(undefined);
 export const translatorContext = createContext<Translator | undefined>(undefined);

--- a/react/src/hooks/useLocale.ts
+++ b/react/src/hooks/useLocale.ts
@@ -1,6 +1,7 @@
+import type { Locale } from "@let-value/translate";
 import { use } from "react";
 import { localeContext } from "../context.ts";
 
-export function useLocale() {
+export function useLocale(): Locale | undefined {
     return use(localeContext);
 }

--- a/react/src/hooks/useTranslations.ts
+++ b/react/src/hooks/useTranslations.ts
@@ -1,4 +1,4 @@
-import type { LocaleTranslator } from "@let-value/translate";
+import type { Locale, LocaleTranslator } from "@let-value/translate";
 import { use } from "react";
 
 import { localeContext, translatorContext } from "../context.ts";
@@ -28,7 +28,7 @@ function getPromiseState(promise: any) {
     }
 }
 
-export function useTranslations(locale?: string): LocaleTranslator {
+export function useTranslations(locale?: Locale): LocaleTranslator {
     const requestedLocale = locale ?? use(localeContext) ?? "unknown";
     const translator = use(translatorContext);
     if (!translator) {

--- a/translate/src/config.ts
+++ b/translate/src/config.ts
@@ -1,0 +1,20 @@
+import type { PluralFormsLocale } from "plural-forms";
+
+export interface Configuration {
+    /**
+     * Locale to use when a specific one is not provided.
+     */
+    defaultLocale: PluralFormsLocale;
+    /**
+     * List of locales supported by the application. Consumers can augment this
+     * interface via module augmentation to provide literal locale strings which
+     * will then be used across the library for strict type checking.
+     */
+    locales: readonly PluralFormsLocale[];
+    /**
+     * Optional map of fallback locales.
+     */
+    fallback?: Partial<Record<PluralFormsLocale, PluralFormsLocale>>;
+}
+
+export type Locale = Configuration["locales"][number];

--- a/translate/src/index.ts
+++ b/translate/src/index.ts
@@ -1,2 +1,3 @@
+export type { Configuration, Locale } from "./config.ts";
 export * from "./messages.ts";
 export * from "./translator.ts";

--- a/translate/src/utils.ts
+++ b/translate/src/utils.ts
@@ -1,4 +1,5 @@
 import { getNPlurals, getPluralFunc } from "plural-forms";
+import type { Locale } from "./config.ts";
 
 // biome-ignore lint/suspicious/noExplicitAny: true
 export type IsUnion<T, U = T> = (T extends any ? (x: T) => 0 : never) extends (x: U) => 0 ? false : true;
@@ -32,7 +33,7 @@ export function substitute(text: string, values: unknown[] = []): string {
 
 const defaultPluralFunc = (n: number) => (n !== 1 ? 1 : 0);
 
-export const pluralFunc = memo(function pluralFunc(locale: string) {
+export const pluralFunc = memo(function pluralFunc(locale: Locale) {
     try {
         const length = Number(getNPlurals(locale));
         const pluralFunc = getPluralFunc(locale);

--- a/translate/test/translator-locale.test.ts
+++ b/translate/test/translator-locale.test.ts
@@ -29,6 +29,6 @@ await test("getLocale throws for async locales", async () => {
         en: empty,
         ru: async () => gettextParser.po.parse(await fs.promises.readFile(ruUrl)),
     });
-    // @ts-expect-error getLocale cannot return async locale
+    // @ts-expect-error async locale cannot be loaded synchronously
     assert.throws(() => t.getLocale("ru"));
 });

--- a/translate/test/utils.test.ts
+++ b/translate/test/utils.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
+import type { Locale } from "../src/config.ts";
 import { memo, pluralFunc, substitute } from "../src/utils.ts";
 
 // substitute replacement behavior
@@ -23,7 +24,7 @@ test("memo caches results for same inputs", () => {
 
 // pluralFunc default behavior for unknown locale
 test("pluralFunc falls back to default when locale is unknown", () => {
-    const pf = pluralFunc("xx");
+    const pf = pluralFunc("xx" as unknown as Locale);
     assert.equal(pf(1), 0);
     assert.equal(pf(2), 1);
 });

--- a/translate/types/plural-forms.d.ts
+++ b/translate/types/plural-forms.d.ts
@@ -1,4 +1,281 @@
 declare module "plural-forms" {
+    export type PluralFormsLocale =
+        | "ach"
+        | "af"
+        | "ak"
+        | "am"
+        | "an"
+        | "ar"
+        | "arn"
+        | "ast"
+        | "ay"
+        | "az"
+        | "be"
+        | "bg"
+        | "bn"
+        | "bo"
+        | "br"
+        | "brx"
+        | "bs"
+        | "ca"
+        | "cgg"
+        | "cs"
+        | "csb"
+        | "cy"
+        | "da"
+        | "de"
+        | "doi"
+        | "dz"
+        | "el"
+        | "en"
+        | "eo"
+        | "es"
+        | "et"
+        | "eu"
+        | "fa"
+        | "ff"
+        | "fi"
+        | "fil"
+        | "fo"
+        | "fr"
+        | "fur"
+        | "fy"
+        | "ga"
+        | "gd"
+        | "gl"
+        | "gu"
+        | "gun"
+        | "ha"
+        | "he"
+        | "hi"
+        | "hne"
+        | "hr"
+        | "hu"
+        | "hy"
+        | "id"
+        | "is"
+        | "it"
+        | "ja"
+        | "jbo"
+        | "jv"
+        | "ka"
+        | "kab"
+        | "kk"
+        | "km"
+        | "kn"
+        | "ko"
+        | "ku"
+        | "kw"
+        | "ky"
+        | "lb"
+        | "ln"
+        | "lo"
+        | "lt"
+        | "lv"
+        | "mai"
+        | "mfe"
+        | "mg"
+        | "mi"
+        | "mk"
+        | "ml"
+        | "mn"
+        | "mni"
+        | "mnk"
+        | "mr"
+        | "ms"
+        | "mt"
+        | "my"
+        | "nah"
+        | "nap"
+        | "nb"
+        | "ne"
+        | "nl"
+        | "nn"
+        | "no"
+        | "nso"
+        | "oc"
+        | "or"
+        | "pa"
+        | "pap"
+        | "pl"
+        | "pms"
+        | "ps"
+        | "pt"
+        | "rm"
+        | "ro"
+        | "ru"
+        | "rw"
+        | "sah"
+        | "sat"
+        | "sco"
+        | "sd"
+        | "se"
+        | "si"
+        | "sk"
+        | "sl"
+        | "so"
+        | "son"
+        | "sq"
+        | "sr"
+        | "su"
+        | "sv"
+        | "sw"
+        | "ta"
+        | "te"
+        | "tg"
+        | "th"
+        | "ti"
+        | "tk"
+        | "tr"
+        | "tt"
+        | "ug"
+        | "uk"
+        | "ur"
+        | "uz"
+        | "vi"
+        | "wa"
+        | "wo"
+        | "yo"
+        | "zh";
+    export const locales: readonly [
+        "ach",
+        "af",
+        "ak",
+        "am",
+        "an",
+        "ar",
+        "arn",
+        "ast",
+        "ay",
+        "az",
+        "be",
+        "bg",
+        "bn",
+        "bo",
+        "br",
+        "brx",
+        "bs",
+        "ca",
+        "cgg",
+        "cs",
+        "csb",
+        "cy",
+        "da",
+        "de",
+        "doi",
+        "dz",
+        "el",
+        "en",
+        "eo",
+        "es",
+        "et",
+        "eu",
+        "fa",
+        "ff",
+        "fi",
+        "fil",
+        "fo",
+        "fr",
+        "fur",
+        "fy",
+        "ga",
+        "gd",
+        "gl",
+        "gu",
+        "gun",
+        "ha",
+        "he",
+        "hi",
+        "hne",
+        "hr",
+        "hu",
+        "hy",
+        "id",
+        "is",
+        "it",
+        "ja",
+        "jbo",
+        "jv",
+        "ka",
+        "kab",
+        "kk",
+        "km",
+        "kn",
+        "ko",
+        "ku",
+        "kw",
+        "ky",
+        "lb",
+        "ln",
+        "lo",
+        "lt",
+        "lv",
+        "mai",
+        "mfe",
+        "mg",
+        "mi",
+        "mk",
+        "ml",
+        "mn",
+        "mni",
+        "mnk",
+        "mr",
+        "ms",
+        "mt",
+        "my",
+        "nah",
+        "nap",
+        "nb",
+        "ne",
+        "nl",
+        "nn",
+        "no",
+        "nso",
+        "oc",
+        "or",
+        "pa",
+        "pap",
+        "pl",
+        "pms",
+        "ps",
+        "pt",
+        "rm",
+        "ro",
+        "ru",
+        "rw",
+        "sah",
+        "sat",
+        "sco",
+        "sd",
+        "se",
+        "si",
+        "sk",
+        "sl",
+        "so",
+        "son",
+        "sq",
+        "sr",
+        "su",
+        "sv",
+        "sw",
+        "ta",
+        "te",
+        "tg",
+        "th",
+        "ti",
+        "tk",
+        "tr",
+        "tt",
+        "ug",
+        "uk",
+        "ur",
+        "uz",
+        "vi",
+        "wa",
+        "wo",
+        "yo",
+        "zh",
+    ];
     export declare function getFormula(language: string): string;
     export declare function getNPlurals(language: string): number;
     export declare function getPluralFunc(
@@ -6,6 +283,6 @@ declare module "plural-forms" {
     ): (plural: number, wordForms: string[]) => string | undefined;
     export declare function hasLang(language: string): boolean;
     export declare function getPluralFormsHeader(language: string): string;
-    export declare function getAvailLangs(): string[];
+    export declare function getAvailLangs(): PluralFormsLocale[];
     export declare function getExamples(language: string): Array<{ plural: number; sample: number }>;
 }


### PR DESCRIPTION
## Summary
- introduce `Configuration` interface with augmentable locale definitions
- type Translator and React helpers with `Locale`
- validate locales against `plural-forms`
- restore generic `Translator` and enforce synchronous locale keys in `getLocale`

## Testing
- `npm run build`
- `npm test`
- `npm run typecheck`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68bd88e20b70832fbaada164281fd011