### PR TITLE
feat(extract): add exclude option for ignored paths

### DIFF
--- a/extract/src/run.ts
+++ b/extract/src/run.ts
@@ -25,12 +25,13 @@ export async function run(
     const entryConfig = config.entrypoints.find((e) => e.entrypoint === entrypoint);
     const destination = entryConfig?.destination ?? config.destination;
     const obsolete = entryConfig?.obsolete ?? config.obsolete;
+    const exclude = entryConfig?.exclude ?? config.exclude;
 
     const queue: ResolveArgs[] = [{ entrypoint, path: entrypoint }];
     const context: ExtractContext = {
         entry: entrypoint,
         dest: dest ?? process.cwd(),
-        config: { ...config, destination, obsolete },
+        config: { ...config, destination, obsolete, exclude },
         generatedAt: new Date(),
         locale,
     };
@@ -42,6 +43,11 @@ export async function run(
     const generates: { filter: RegExp; hook: GenerateHook }[] = [];
 
     function resolvePath(args: ResolveArgs) {
+        for (const ex of context.config.exclude) {
+            if (ex instanceof RegExp ? ex.test(args.path) : ex(args.path)) {
+                return;
+            }
+        }
         if (context.config.walk) {
             queue.push(args);
         }

--- a/extract/src/tests/configuration.test.ts
+++ b/extract/src/tests/configuration.test.ts
@@ -75,3 +75,23 @@ test("configures walk option", () => {
     const cfg2 = defineConfig({ entrypoints: "src/index.ts", walk: false });
     assert.equal(cfg2.walk, false);
 });
+
+test("provides default excludes", () => {
+    const cfg = defineConfig({ entrypoints: "src/index.ts" });
+    for (const p of ["foo/node_modules/bar.ts", "foo/dist/bar.ts", "foo/build/bar.ts"]) {
+        assert(cfg.exclude.some((e) => (e instanceof RegExp ? e.test(p) : e(p))));
+    }
+});
+
+test("supports exclude overrides", () => {
+    const cfg = defineConfig({
+        entrypoints: [{ entrypoint: "src/index.ts", exclude: /skip/ }],
+        exclude: /global/,
+    });
+    assert(cfg.exclude.some((e) => (e instanceof RegExp ? e.test("global") : e("global"))));
+    const epExclude = cfg.entrypoints[0].exclude;
+    assert(epExclude);
+    assert(epExclude.some((e) => (e instanceof RegExp ? e.test("skip") : e("skip"))));
+    assert(!epExclude.some((e) => (e instanceof RegExp ? e.test("global") : e("global"))));
+    assert(epExclude.some((e) => (e instanceof RegExp ? e.test("node_modules/foo") : e("node_modules/foo"))));
+});


### PR DESCRIPTION
## Summary
- add configurable `exclude` patterns to extraction config and entrypoints
- skip resolving paths matching exclusion rules
- document defaults and tests for ignoring `node_modules`, `dist`, and `build`

## Testing
- `npm test -w extract`
- `npm run check -w extract`


------
https://chatgpt.com/codex/tasks/task_e_68c176032348832fa4b3a50496c96fa7