### PR TITLE
Refactor extraction to process default locale once

### DIFF
--- a/extract/bin/cli.ts
+++ b/extract/bin/cli.ts
@@ -45,11 +45,10 @@ async function main() {
     const config = result.config as ResolvedConfig;
     config.logLevel = (logLevel as LevelWithSilent | undefined) ?? config.logLevel;
     logger.level = config.logLevel;
+
     const tasks: Promise<unknown>[] = [];
-    for (const locale of config.locales) {
-        for (const ep of config.entrypoints) {
-            tasks.push(run(ep.entrypoint, { locale, config, logger }));
-        }
+    for (const ep of config.entrypoints) {
+        tasks.push(run(ep.entrypoint, { config, logger }));
     }
 
     await Promise.all(tasks);


### PR DESCRIPTION
## Summary
- run extraction once using the default locale and then generate translations for each configured locale
- simplify CLI to invoke extraction per entrypoint instead of per locale
- add test ensuring extraction runs once while generating for all locales

## Testing
- `npm test -w extract`
- `npm run typecheck -w extract`
- `npm run check -w extract`


------
https://chatgpt.com/codex/tasks/task_e_68c1960a22a0832fb15031768ed86efa