### PR TITLE
test: add end-to-end translation tests

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,18 @@
+{
+    "name": "@let-value/translate-e2e",
+    "version": "1.0.9-beta.3",
+    "private": true,
+    "type": "module",
+    "dependencies": {
+        "@let-value/translate": "1.0.9-beta.3",
+        "@let-value/translate-extract": "1.0.9-beta.3",
+        "gettext-parser": "8.0.0"
+    },
+    "scripts": {
+        "build": "tsc -p tsconfig.json",
+        "check": "biome check .",
+        "format": "biome check --write .",
+        "typecheck": "tsc --build",
+        "test": "node --test"
+    }
+}

--- a/e2e/test/app/app.ts
+++ b/e2e/test/app/app.ts
@@ -1,0 +1,24 @@
+import fs from "node:fs/promises";
+import * as gettextParser from "gettext-parser";
+import { Translator, message } from "@let-value/translate";
+
+const name = "World";
+
+export async function runApp(locale: string, count: number) {
+    const translations: Record<string, gettextParser.GetTextTranslations> = {};
+    try {
+        const url = new URL(`./translations/app.${locale}.po`, import.meta.url);
+        const content = await fs.readFile(url);
+        translations[locale] = gettextParser.po.parse(content);
+    } catch {
+        // missing translation file
+    }
+    const t = new Translator(translations).getLocale(locale as never);
+    const greeting = t.message(message`こんにちは、${name}！`);
+    const items = t.ngettext(
+        message`りんご`,
+        message`${count} りんご`,
+        count,
+    );
+    return { greeting, items };
+}

--- a/e2e/test/e2e.test.ts
+++ b/e2e/test/e2e.test.ts
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+import * as gettextParser from "gettext-parser";
+import { defineConfig, run } from "@let-value/translate-extract";
+
+import { runApp } from "./app/app.ts";
+
+const appPath = fileURLToPath(new URL("./app/app.ts", import.meta.url));
+const appDir = dirname(appPath);
+const translationsDir = join(appDir, "translations");
+
+async function extract() {
+    await fs.rm(translationsDir, { recursive: true, force: true });
+    const config = defineConfig({
+        entrypoints: appPath,
+        locales: ["en", "ru", "sl"],
+        defaultLocale: "ja",
+    });
+    await run(appPath, { config });
+}
+
+async function update(locale: string, greeting: string, forms: string[]) {
+    const file = join(translationsDir, `app.${locale}.po`);
+    const po = gettextParser.po.parse(await fs.readFile(file));
+    const msgs = po.translations[""];
+    const helloKey = "こんにちは、${name}！";
+    const hello = msgs[helloKey]!;
+    delete msgs[helloKey];
+    hello.msgid = "こんにちは、${0}！";
+    hello.msgstr[0] = greeting;
+    msgs["こんにちは、${0}！"] = hello;
+
+    const pluralKey = "りんご";
+    const entry = msgs[pluralKey]!;
+    delete msgs[pluralKey];
+    entry.msgid = "りんご";
+    entry.msgid_plural = "${0} りんご";
+    entry.msgstr = forms;
+    msgs["りんご"] = entry;
+
+    await fs.writeFile(file, gettextParser.po.compile(po));
+}
+
+test("node app works end to end", async (t) => {
+    await extract();
+    t.after(async () => {
+        await fs.rm(translationsDir, { recursive: true, force: true });
+    });
+
+    // Default locale - Japanese
+    let result = await runApp("ja", 1);
+    assert.equal(result.greeting, "こんにちは、World！");
+    assert.equal(result.items, "りんご");
+    result = await runApp("ja", 2);
+    assert.equal(result.items, "りんご");
+
+    // English before translation
+    result = await runApp("en", 1);
+    assert.equal(result.greeting, "こんにちは、World！");
+    assert.equal(result.items, "りんご");
+    result = await runApp("en", 2);
+    assert.equal(result.items, "2 りんご");
+
+    await update("en", "Hello, ${0}!", ["apple", "${0} apples"]);
+    result = await runApp("en", 1);
+    assert.equal(result.greeting, "Hello, World!");
+    assert.equal(result.items, "apple");
+    result = await runApp("en", 2);
+    assert.equal(result.items, "2 apples");
+
+    // Russian before translation
+    result = await runApp("ru", 1);
+    assert.equal(result.greeting, "こんにちは、World！");
+    assert.equal(result.items, "りんご");
+    result = await runApp("ru", 2);
+    assert.equal(result.items, "2 りんご");
+    result = await runApp("ru", 5);
+    assert.equal(result.items, "5 りんご");
+
+    await update("ru", "Привет, ${0}!", ["яблоко", "${0} яблока", "${0} яблок"]);
+    result = await runApp("ru", 1);
+    assert.equal(result.greeting, "Привет, World!");
+    assert.equal(result.items, "яблоко");
+    result = await runApp("ru", 2);
+    assert.equal(result.items, "2 яблока");
+    result = await runApp("ru", 5);
+    assert.equal(result.items, "5 яблок");
+
+    // Slovenian before translation
+    result = await runApp("sl", 1);
+    assert.equal(result.greeting, "こんにちは、World！");
+    assert.equal(result.items, "りんご");
+    result = await runApp("sl", 2);
+    assert.equal(result.items, "2 りんご");
+    result = await runApp("sl", 3);
+    assert.equal(result.items, "3 りんご");
+    result = await runApp("sl", 5);
+    assert.equal(result.items, "りんご");
+
+    await update(
+        "sl",
+        "Živjo, ${0}!",
+        ["jabolk", "jabolko", "${0} jabolka", "${0} jabolki"],
+    );
+    result = await runApp("sl", 1);
+    assert.equal(result.greeting, "Živjo, World!");
+    assert.equal(result.items, "jabolko");
+    result = await runApp("sl", 2);
+    assert.equal(result.items, "2 jabolka");
+    result = await runApp("sl", 3);
+    assert.equal(result.items, "3 jabolki");
+    result = await runApp("sl", 5);
+    assert.equal(result.items, "jabolk");
+
+    // Missing translations fallback
+    result = await runApp("fr", 2);
+    assert.equal(result.greeting, "こんにちは、World！");
+    assert.equal(result.items, "2 りんご");
+});

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,15 @@
+{
+    "extends": "../tsconfig.base.json",
+    "compilerOptions": {
+        "composite": true,
+        "declaration": true,
+        "emitDeclarationOnly": true,
+        "declarationMap": true,
+        "outDir": "dist"
+    },
+    "include": ["test/**/*.ts"],
+    "references": [
+        { "path": "../translate" },
+        { "path": "../extract" }
+    ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
                 "loader",
                 "translate",
                 "extract",
-                "react"
+                "react",
+                "e2e"
             ],
             "devDependencies": {
                 "@biomejs/biome": "2.2.2",
@@ -20,6 +21,15 @@
             },
             "engines": {
                 "node": ">=22"
+            }
+        },
+        "e2e": {
+            "name": "@let-value/translate-e2e",
+            "version": "1.0.9-beta.3",
+            "dependencies": {
+                "@let-value/translate": "1.0.9-beta.3",
+                "@let-value/translate-extract": "1.0.9-beta.3",
+                "gettext-parser": "8.0.0"
             }
         },
         "extract": {
@@ -434,6 +444,10 @@
         },
         "node_modules/@let-value/translate": {
             "resolved": "translate",
+            "link": true
+        },
+        "node_modules/@let-value/translate-e2e": {
+            "resolved": "e2e",
             "link": true
         },
         "node_modules/@let-value/translate-extract": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
         "loader",
         "translate",
         "extract",
-        "react"
+        "react",
+        "e2e"
     ],
     "engines": {
         "node": ">=22"

--- a/translate/src/translator.ts
+++ b/translate/src/translator.ts
@@ -48,12 +48,18 @@ export class LocaleTranslator {
 
     private translatePlural({ forms, n }: PluralMessage, msgctxt = ""): string {
         const entry = this.translations?.translations?.[msgctxt]?.[forms[0].msgid];
-        const index = pluralFunc(this.locale)(n);
-        const form = forms[index] ?? forms[forms.length - 1];
+        const pf = pluralFunc(this.locale);
+        const index = pf(n);
+        const singularIndex = pf(1);
+        const baseForm = forms[index] ?? forms[forms.length - 1];
         const translated = entry?.msgstr?.[index];
-        const result = translated?.length ? translated : form.msgstr;
-        const usedVals = form.values?.length ? form.values : forms[0].values;
-        return usedVals?.length ? substitute(result, usedVals) : result;
+        if (translated?.length) {
+            const used = baseForm.values?.length ? baseForm.values : forms[0].values;
+            return used?.length ? substitute(translated, used) : translated;
+        }
+        const fallbackForm = index === singularIndex ? forms[0] : baseForm;
+        const usedVals = fallbackForm.values?.length ? fallbackForm.values : forms[0].values;
+        return usedVals?.length ? substitute(fallbackForm.msgstr, usedVals) : fallbackForm.msgstr;
     }
 
     message = <T extends string>(...args: MessageInput<T>): string => {


### PR DESCRIPTION
## Summary
- set default locale to Japanese in e2e sample
- use Japanese plural forms and sequentially apply translations for each locale
- verify fallback behavior before translation and plural handling after
- fix Slovenian plural matching so untranslated singular uses the singular form

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2b6f0e338832fb2c4dac2186444b0