### PR TITLE
Handle Slovak plural forms and enforce plural counts

### DIFF
--- a/e2e/tests/node/node.test.ts
+++ b/e2e/tests/node/node.test.ts
@@ -16,7 +16,7 @@ async function extract() {
     await fs.rm(translationsDir, { recursive: true, force: true });
     const config = defineConfig({
         entrypoints: appPath,
-        locales: ["en", "ru", "sl"],
+        locales: ["en", "ru", "sl", "sk"],
         defaultLocale: "ja",
     });
     await run(appPath, { config });
@@ -120,7 +120,7 @@ test("node app works end to end", async (t) => {
         translated: "Zamujeno sporočilo",
         def: "Privzeto sporočilo",
         greeting: "Živjo, ${name}!",
-        forms: ["jabolko", "${count} jabolka", "${count} jabolki", "jabolk"],
+        forms: ["jabolk", "jabolko", "${count} jabolka", "${count} jabolki"],
     });
     result = await runApp("sl", 1);
     assert.equal(result.translated, "Zamujeno sporočilo");
@@ -133,6 +133,33 @@ test("node app works end to end", async (t) => {
     assert.equal(result.items, "3 jabolki");
     result = await runApp("sl", 5);
     assert.equal(result.items, "jabolk");
+
+    // Slovak before translation
+    result = await runApp("sk", 1);
+    assert.equal(result.translated, "延期されたメッセージ");
+    assert.equal(result.def, "デフォルトメッセージ");
+    assert.equal(result.greeting, "こんにちは、World！");
+    assert.equal(result.items, "りんご");
+    result = await runApp("sk", 2);
+    assert.equal(result.items, "2 りんご");
+    result = await runApp("sk", 5);
+    assert.equal(result.items, "5 りんご");
+
+    await update("sk", {
+        translated: "Odložená správa",
+        def: "Predvolená správa",
+        greeting: "Ahoj, ${name}!",
+        forms: ["jablko", "${count} jablká", "${count} jabĺk"],
+    });
+    result = await runApp("sk", 1);
+    assert.equal(result.translated, "Odložená správa");
+    assert.equal(result.def, "Predvolená správa");
+    assert.equal(result.greeting, "Ahoj, World!");
+    assert.equal(result.items, "jablko");
+    result = await runApp("sk", 2);
+    assert.equal(result.items, "2 jablká");
+    result = await runApp("sk", 5);
+    assert.equal(result.items, "5 jabĺk");
 
     // Missing translations fallback
     result = await runApp("fr", 2);

--- a/extract/src/plugins/po/po.ts
+++ b/extract/src/plugins/po/po.ts
@@ -46,11 +46,14 @@ export function collect(source: Translation[], locale?: string): GetTextTranslat
             });
         }
 
+        const msgstr = existing?.msgstr ? existing.msgstr.slice(0, length) : Array.from({ length }, () => "");
+        while (msgstr.length < length) msgstr.push("");
+
         translations[ctx][id] = {
             msgctxt: context || undefined,
             msgid: id,
             msgid_plural: plural,
-            msgstr: existing?.msgstr ?? Array.from({ length }, () => ""),
+            msgstr,
             comments: {
                 ...existing?.comments,
                 ...comments,

--- a/translate/src/translator.ts
+++ b/translate/src/translator.ts
@@ -50,7 +50,9 @@ export class LocaleTranslator {
         const entry = this.translations?.translations?.[msgctxt]?.[forms[0].msgid];
         const index = pluralFunc(this.locale)(n);
         const form = forms[index] ?? forms[forms.length - 1];
-        const translated = entry?.msgstr?.[index];
+        const translated = entry?.msgstr
+            ? entry.msgstr[index] ?? entry.msgstr[entry.msgstr.length - 1]
+            : undefined;
         const result = translated || form.msgstr;
         const usedVals = form.values?.length ? form.values : forms[0].values;
         return usedVals?.length ? substitute(result, usedVals) : result;

--- a/translate/src/utils.ts
+++ b/translate/src/utils.ts
@@ -92,9 +92,9 @@ export const pluralFunc = memo(function pluralFunc(locale: Locale) {
         const forms = Array.from({ length }, (_, i) => String(i));
         return (n: number) => {
             const idx = Number(pluralFunc(n, forms));
-            if (idx < 0) return 0;
+            if (!Number.isFinite(idx) || idx < 0) return 0;
             if (idx >= length) return length - 1;
-            return idx;
+            return Math.floor(idx);
         };
     } catch {
         return defaultPluralFunc;

--- a/translate/test/fixtures/sk.po
+++ b/translate/test/fixtures/sk.po
@@ -1,0 +1,10 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Plural-Forms: nplurals=3; plural=(n==1?0:n>=2 && n<=4?1:2);\n"
+
+msgid "${0} apple"
+msgid_plural "${0} apples"
+msgstr[0] "${0} jablko"
+msgstr[1] "${0} jablká"
+msgstr[2] "${0} jabĺk"

--- a/translate/test/translator-plural.test.ts
+++ b/translate/test/translator-plural.test.ts
@@ -14,6 +14,7 @@ const translations = {
     en: load("en"),
     ru: load("ru"),
     ja: load("ja"),
+    sk: load("sk"),
 };
 
 test("plural handles English plurals", () => {
@@ -33,6 +34,15 @@ test("plural handles Japanese singular form for any number", () => {
     const t = new Translator(translations).getLocale("ja");
     for (const n of [0, 1, 2, 5]) {
         assert.equal(t.plural(message`${n} apple`, message`${n} apples`, n), "りんご");
+    }
+});
+
+test("plural handles Slovak plurals for any number", () => {
+    const t = new Translator(translations).getLocale("sk");
+    for (let n = 0; n < 200; n++) {
+        const expected =
+            n === 1 ? `${n} jablko` : n >= 2 && n <= 4 ? `${n} jablká` : `${n} jabĺk`;
+        assert.equal(t.plural(message`${n} apple`, message`${n} apples`, n), expected);
     }
 });
 


### PR DESCRIPTION
## Summary
- guard plural form selection against invalid indices
- clamp plural translations and ensure extraction outputs nplurals entries
- add Slovak regression tests and e2e coverage

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c2e1a10090832f8aef760ee5a4de5a