### PR TITLE
Fix React e2e test parsing with comment markers

### DIFF
--- a/e2e/tests/react/app.tsx
+++ b/e2e/tests/react/app.tsx
@@ -59,7 +59,8 @@ export async function runApp(locale: string, count: number) {
     const html = await render(element);
 
     function match(id: string) {
-        return html.match(new RegExp(`<div id="${id}">([^<]*)</div>`))?.[1] ?? "";
+        const clean = html.replace(/<!--[^>]*-->/g, "");
+        return clean.match(new RegExp(`<div id="${id}">([^<]*)</div>`))?.[1] ?? "";
     }
 
     return {


### PR DESCRIPTION
## Summary
- strip React's server-rendered comment markers before matching text in e2e React app helper

## Testing
- `npm test --workspace=e2e`


------
https://chatgpt.com/codex/tasks/task_e_68c419a06b04832fb1b00e507a6170e2