### PR TITLE
Refactor run pipeline without result graph

### DIFF
--- a/e2e/tests/node/node.test.ts
+++ b/e2e/tests/node/node.test.ts
@@ -20,7 +20,7 @@ async function extract() {
         locales: ["en", "ru", "sl", "sk"],
         defaultLocale: "ja",
     });
-    await run(appPath, { config });
+    await run(config.entrypoints[0], { config });
 }
 
 async function update(

--- a/e2e/tests/react/react.test.ts
+++ b/e2e/tests/react/react.test.ts
@@ -20,7 +20,7 @@ async function extract() {
         defaultLocale: "ja",
         plugins: [react()],
     });
-    await run(appPath, { config });
+    await run(config.entrypoints[0], { config });
 }
 
 async function loadRunApp() {

--- a/extract/src/plugin.ts
+++ b/extract/src/plugin.ts
@@ -51,33 +51,6 @@ export interface ProcessResult<TOutput = unknown> {
     data: TOutput;
 }
 
-export class ResultGraph {
-    data = new Map<string, Map<string, unknown[]>>();
-
-    add(namespace: string, path: string, result: unknown): void {
-        if (!this.data.has(namespace)) {
-            this.data.set(namespace, new Map());
-        }
-        // biome-ignore lint/style/noNonNullAssertion: true
-        const map = this.data.get(namespace)!;
-        if (!map.has(path)) {
-            map.set(path, []);
-        }
-        // biome-ignore lint/style/noNonNullAssertion: true
-        map.get(path)!.push(result);
-    }
-
-    get<T = unknown>(namespace: string, path: string): T[] | undefined {
-        return this.data.get(namespace)?.get(path) as T[] | undefined;
-    }
-
-    entries<T = unknown>(namespace: string): Array<[string, T[]]> {
-        const nsMap = this.data.get(namespace);
-        if (!nsMap) return [];
-        return Array.from(nsMap.entries()) as Array<[string, T[]]>;
-    }
-}
-
 export type Filter = { filter: RegExp; namespace?: string };
 export type ResolveHook<TInput = unknown> = (
     args: ResolveArgs<TInput>,

--- a/extract/src/plugins/cleanup/cleanup.ts
+++ b/extract/src/plugins/cleanup/cleanup.ts
@@ -21,7 +21,7 @@ export function cleanup(): Plugin {
             build.onProcess({ namespace: "cleanup", filter: /.*/ }, async ({ path }) => {
                 await build.defer("translate");
                 const dir = dirname(path);
-                if (processedDirs.has(dir)) return;
+                if (processedDirs.has(dir)) return undefined;
                 processedDirs.add(dir);
                 const files = await fs.readdir(dir).catch(() => []);
                 for (const f of files.filter((p) => p.endsWith(".po"))) {
@@ -41,6 +41,7 @@ export function cleanup(): Plugin {
                         build.context.logger?.info({ path: full }, "removed empty translation file");
                     }
                 }
+                return undefined;
             });
         },
     };

--- a/extract/src/plugins/cleanup/tests/cleanup.test.ts
+++ b/extract/src/plugins/cleanup/tests/cleanup.test.ts
@@ -43,6 +43,7 @@ test("removes empty stray translation files", async () => {
                     path: generated,
                     namespace: "cleanup",
                 });
+                return undefined;
             });
         },
     };

--- a/extract/src/plugins/po/merge.test.ts
+++ b/extract/src/plugins/po/merge.test.ts
@@ -21,7 +21,13 @@ function createExisting() {
 }
 
 function runMerge(sources: GetTextTranslationRecord[], existing: string | undefined, strategy: "mark" | "remove") {
-    return merge(sources, existing, strategy, "en", date);
+    return merge(
+        sources.map((translations) => ({ translations })),
+        existing,
+        strategy,
+        "en",
+        date,
+    );
 }
 
 test("marks missing translations as obsolete", () => {

--- a/extract/src/plugins/po/po.ts
+++ b/extract/src/plugins/po/po.ts
@@ -213,7 +213,7 @@ export function po(): Plugin {
                     }
                     dispatched = true;
 
-                    for (const path of Object.keys(collections)) {
+                    for (const path of collections.keys()) {
                         build.load({ entrypoint, path, namespace });
                     }
                 });
@@ -233,7 +233,7 @@ export function po(): Plugin {
 
             build.onProcess({ filter: /.*\.po$/, namespace }, async ({ entrypoint, path, data }) => {
                 const collected = collections.get(path);
-                if (!collected || !data) {
+                if (!collected) {
                     build.context.logger?.warn({ path }, "no translations collected for this path");
                     return undefined;
                 }

--- a/extract/src/plugins/po/tests/dedupe.test.ts
+++ b/extract/src/plugins/po/tests/dedupe.test.ts
@@ -16,8 +16,8 @@ test("deduplicates messages and preserves references", () => {
 
     const out = merge(
         [
-            { entrypoint: "a.js", path: "a.js", destination: "messages.po", translations: recA },
-            { entrypoint: "b.js", path: "b.js", destination: "messages.po", translations: recB },
+            { translations: recA },
+            { translations: recB },
         ],
         undefined,
         "mark",

--- a/extract/src/plugins/po/tests/header.test.ts
+++ b/extract/src/plugins/po/tests/header.test.ts
@@ -1,18 +1,10 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import type { CollectResult } from "../../../plugin.ts";
-import { formatDate, merge } from "../po.ts";
+import { formatDate, merge, type Collected } from "../po.ts";
 
 test("sets POT-Creation-Date header from context timestamp", () => {
     const timestamp = new Date("2023-01-02T03:04:00Z");
-    const collected: CollectResult[] = [
-        {
-            entrypoint: "entry.ts",
-            path: "entry.ts",
-            destination: "messages.po",
-            translations: { "": {} },
-        },
-    ];
+    const collected: Collected[] = [{ translations: { "": {} } }];
     const out = merge(collected, undefined, "mark", "en", timestamp);
     assert.ok(out.includes(`POT-Creation-Date: ${formatDate(timestamp)}`));
 });

--- a/extract/src/plugins/po/tests/parity.test.ts
+++ b/extract/src/plugins/po/tests/parity.test.ts
@@ -23,13 +23,9 @@ test("matches xgettext output", async () => {
 
     const { translations } = parseFile(fixture);
     const record = collect(translations, "en");
-    const out = merge(
-        [{ entrypoint: fixture, path: fixture, destination: "messages.po", translations: record }],
-        undefined,
-        "mark",
-        "en",
-        new Date(),
-    );
+    const out = merge([
+        { translations: record },
+    ], undefined, "mark", "en", new Date());
     const ours = gettextParser.po.parse(out);
 
     assert.deepEqual(normalize(ours), normalize(ref));
@@ -42,13 +38,9 @@ test("matches xgettext output for 4 plural forms", async () => {
 
     const { translations } = parseFile(fixture);
     const record = collect(translations, "sl");
-    const out = merge(
-        [{ entrypoint: fixture, path: fixture, destination: "messages.po", translations: record }],
-        undefined,
-        "mark",
-        "sl",
-        new Date(),
-    );
+    const out = merge([
+        { translations: record },
+    ], undefined, "mark", "sl", new Date());
     const ours = gettextParser.po.parse(out);
 
     assert.deepEqual(normalize(ours), normalize(ref));

--- a/extract/src/plugins/po/tests/preserve.test.ts
+++ b/extract/src/plugins/po/tests/preserve.test.ts
@@ -16,7 +16,7 @@ test("preserves existing translations and comments", async () => {
     const record = collect(translations, "en");
 
     const out = merge(
-        [{ entrypoint: fixture, path: fixture, destination: "messages.po", translations: record }],
+        [{ translations: record }],
         existing,
         "mark",
         "en",

--- a/extract/src/tests/configuration.test.ts
+++ b/extract/src/tests/configuration.test.ts
@@ -2,9 +2,9 @@ import assert from "node:assert/strict";
 import { join } from "node:path";
 import { test } from "node:test";
 import { type DestinationFn, defineConfig } from "../configuration.ts";
-import type { ExtractorPlugin } from "../plugin.ts";
+import type { Plugin } from "../plugin.ts";
 
-const mockPlugin: ExtractorPlugin = { name: "mock", setup() {} };
+const mockPlugin: Plugin = { name: "mock", setup() {} };
 
 test("appends plugins when array provided", () => {
     const cfg = defineConfig({ entrypoints: "src/index.ts", plugins: [mockPlugin] });

--- a/extract/src/tests/run.test.ts
+++ b/extract/src/tests/run.test.ts
@@ -75,6 +75,7 @@ test("skips resolving additional files when walk disabled", async () => {
                     path: extra,
                     namespace: "source",
                 });
+                return undefined;
             });
         },
     };
@@ -109,6 +110,7 @@ test("skips resolving paths matching exclude", async () => {
                     path: extra,
                     namespace: "source",
                 });
+                return undefined;
             });
         },
     };

--- a/loader/package.json
+++ b/loader/package.json
@@ -66,7 +66,7 @@
         "check": "biome check .",
         "format": "biome check --write .",
         "typecheck": "tsc --build",
-        "test": "node --test \"**/*.test.ts\""
+        "test": "node --test"
     },
     "peerDependencies": {
         "@types/bun": "1.2.21"


### PR DESCRIPTION
## Summary
- unskip Node and React e2e tests
- fix PO plugin to generate translation files and dispatch cleanup
- allow multiple plugins to process the same stage in the run pipeline
- simplify loader test script to avoid glob failures

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7f5a173d8832f8304ce6e48833321