### PR TITLE
Handle ampersands in multiline React messages

### DIFF
--- a/extract/src/plugins/react/queries/utils.ts
+++ b/extract/src/plugins/react/queries/utils.ts
@@ -1,45 +1,99 @@
 import type Parser from "tree-sitter";
 
 export function buildTemplate(node: Parser.SyntaxNode): { text: string; error?: string } {
+    const source = node.tree.rootNode.text;
+    const open = node.childForFieldName("open_tag");
+    const close = node.childForFieldName("close_tag");
+    const contentStart = open?.endIndex ?? node.startIndex;
+    const contentEnd = close?.startIndex ?? node.endIndex;
+
+    type Part =
+        | { kind: "text"; text: string; raw: boolean }
+        | { kind: "expr"; value: string };
+
+    const parts: Part[] = [];
+    let segmentStart = contentStart;
+
+    const pushRawText = (endIndex: number) => {
+        if (endIndex <= segmentStart) {
+            segmentStart = Math.max(segmentStart, endIndex);
+            return;
+        }
+        const text = source.slice(segmentStart, endIndex);
+        if (text) {
+            parts.push({ kind: "text", text, raw: true });
+        }
+        segmentStart = endIndex;
+    };
+
     const children = node.namedChildren.slice(1, -1);
-    const strings: string[] = [""];
-    const values: string[] = [];
-    for (let i = 0; i < children.length; i++) {
-        const child = children[i];
-        if (child.type === "jsx_text") {
-            let text = child.text;
-            if (i === 0) text = text.replace(/^\s+/, "");
-            if (i === children.length - 1) text = text.replace(/\s+$/, "");
-            if (text) strings[strings.length - 1] += text;
-        } else if (child.type === "jsx_expression") {
+    for (const child of children) {
+        if (child.type === "jsx_expression") {
+            pushRawText(child.startIndex);
             const expr = child.namedChildren[0];
             if (!expr) {
                 return { text: "", error: "Empty JSX expression" };
             }
-            
+
             if (expr.type === "identifier") {
-                values.push(expr.text);
-                strings.push("");
+                parts.push({ kind: "expr", value: expr.text });
             } else if (expr.type === "string") {
-                strings[strings.length - 1] += expr.text.slice(1, -1);
+                parts.push({ kind: "text", text: expr.text.slice(1, -1), raw: false });
             } else if (expr.type === "template_string") {
-                // Check if it's a simple template string with no substitutions
                 const hasSubstitutions = expr.children.some(c => c.type === "template_substitution");
                 if (hasSubstitutions) {
                     return { text: "", error: "JSX expressions with template substitutions are not supported" };
                 }
-                // Extract the text content from the template string
-                const content = expr.text.slice(1, -1); // Remove backticks
-                strings[strings.length - 1] += content;
+                parts.push({ kind: "text", text: expr.text.slice(1, -1), raw: false });
             } else {
                 return { text: "", error: "JSX expressions must be simple identifiers, strings, or template literals" };
             }
+            segmentStart = child.endIndex;
         } else if (child.type === "string") {
-            strings[strings.length - 1] += child.text.slice(1, -1);
+            pushRawText(child.startIndex);
+            parts.push({ kind: "text", text: child.text.slice(1, -1), raw: false });
+            segmentStart = child.endIndex;
+        } else if (child.type === "jsx_text" || child.type === "html_character_reference" || child.isError) {
+            continue;
         } else {
             return { text: "", error: "Unsupported JSX child" };
         }
     }
+
+    pushRawText(contentEnd);
+
+    const firstRawIndex = parts.findIndex(part => part.kind === "text" && part.raw);
+    if (firstRawIndex === 0) {
+        const part = parts[firstRawIndex] as Extract<Part, { kind: "text" }>;
+        part.text = part.text.replace(/^\s+/, "");
+    }
+
+    let lastRawIndex = -1;
+    for (let i = parts.length - 1; i >= 0; i--) {
+        const part = parts[i];
+        if (part.kind === "text" && part.raw) {
+            lastRawIndex = i;
+            break;
+        }
+    }
+    if (lastRawIndex !== -1 && lastRawIndex === parts.length - 1) {
+        const part = parts[lastRawIndex] as Extract<Part, { kind: "text" }>;
+        part.text = part.text.replace(/\s+$/, "");
+    }
+
+    const strings: string[] = [""];
+    const values: string[] = [];
+    for (const part of parts) {
+        if (part.kind === "text") {
+            if (part.text) {
+                strings[strings.length - 1] += part.text;
+            }
+        } else {
+            values.push(part.value);
+            strings.push("");
+        }
+    }
+
     let text = "";
     for (let i = 0; i < strings.length; i++) {
         text += strings[i];

--- a/extract/src/plugins/react/tests/fixtures/valid.tsx
+++ b/extract/src/plugins/react/tests/fixtures/valid.tsx
@@ -18,3 +18,6 @@ const privacyPolicy = <Message>Privacy Policy</Message>;
 <Message>
     {termsOfService} • {privacyPolicy} • {cookiePolicy}
 </Message>;
+<Message>
+    By signing up you’re 16+ and accept {termsOfService} & {privacyPolicy}.
+</Message>;

--- a/extract/src/plugins/react/tests/react.test.ts
+++ b/extract/src/plugins/react/tests/react.test.ts
@@ -32,6 +32,12 @@ suite("react plugin", () => {
                 plural: undefined,
                 context: undefined,
             },
+            {
+                id: "By signing up you’re 16+ and accept ${termsOfService} & ${privacyPolicy}.",
+                message: ["By signing up you’re 16+ and accept ${termsOfService} & ${privacyPolicy}."],
+                plural: undefined,
+                context: undefined,
+            },
             { id: "one", plural: "many", message: ["one", "many"], context: undefined },
             {
                 id: "One ${name}",


### PR DESCRIPTION
## Summary
- add a multiline `<Message>` fixture covering inline text with ampersands
- verify the extracted translations include the new message
- rebuild the React extractor template builder to collect raw text segments so ampersands are captured without relying on ERROR nodes

## Testing
- npm test --workspace extract

------
https://chatgpt.com/codex/tasks/task_e_68c98b7378bc832f9e6c7771705884d3