### PR TITLE
Replace Pino with loglevel in extract package

### DIFF
--- a/extract/bin/cli.ts
+++ b/extract/bin/cli.ts
@@ -2,7 +2,7 @@
 import { parseArgs } from "node:util";
 import { cosmiconfig } from "cosmiconfig";
 import type { ResolvedConfig } from "../src/configuration.ts";
-import { createLogger, type LogLevel } from "../src/logger.ts";
+import { type LogLevel, logger } from "../src/logger.ts";
 import { run } from "../src/run.ts";
 
 const moduleName = "translate";
@@ -16,8 +16,6 @@ async function main() {
             logLevel: { type: "string", short: "l" },
         },
     });
-
-    const logger = createLogger(logLevel as LogLevel | undefined);
 
     const explorer = cosmiconfig(moduleName, {
         searchPlaces: [
@@ -55,7 +53,6 @@ async function main() {
 }
 
 void main().catch((err) => {
-    const logger = createLogger();
     logger.error(err);
     process.exit(1);
 });

--- a/extract/bin/cli.ts
+++ b/extract/bin/cli.ts
@@ -2,7 +2,7 @@
 import { parseArgs } from "node:util";
 import { cosmiconfig } from "cosmiconfig";
 import type { ResolvedConfig } from "../src/configuration.ts";
-import { createLogger, type LevelWithSilent } from "../src/logger.ts";
+import { createLogger, type LogLevel } from "../src/logger.ts";
 import { run } from "../src/run.ts";
 
 const moduleName = "translate";
@@ -17,7 +17,7 @@ async function main() {
         },
     });
 
-    const logger = createLogger(logLevel as LevelWithSilent | undefined);
+    const logger = createLogger(logLevel as LogLevel | undefined);
 
     const explorer = cosmiconfig(moduleName, {
         searchPlaces: [
@@ -43,8 +43,8 @@ async function main() {
     }
 
     const config = result.config as ResolvedConfig;
-    config.logLevel = (logLevel as LevelWithSilent) ?? config.logLevel;
-    logger.level = config.logLevel;
+    config.logLevel = (logLevel as LogLevel) ?? config.logLevel;
+    logger.setLevel(config.logLevel);
 
     const tasks: Promise<unknown>[] = [];
     for (const entrypoint of config.entrypoints) {

--- a/extract/package.json
+++ b/extract/package.json
@@ -21,17 +21,18 @@
     ],
     "dependencies": {
         "@let-value/translate": "1.0.13",
+        "chalk": "5.3.0",
+        "cosmiconfig": "9.0.0",
         "gettext-parser": "8.0.0",
+        "glob": "11.0.3",
+        "loglevel": "1.9.1",
+        "loglevel-plugin-prefix": "0.8.4",
         "oxc-resolver": "11.8.0",
         "plural-forms": "0.5.5",
         "radash": "12.1.1",
         "tree-sitter": "0.25.0",
         "tree-sitter-javascript": "0.25.0",
-        "tree-sitter-typescript": "0.23.2",
-        "glob": "11.0.3",
-        "cosmiconfig": "9.0.0",
-        "pino": "9.9.5",
-        "pino-pretty": "13.1.1"
+        "tree-sitter-typescript": "0.23.2"
     },
     "devDependencies": {
         "@types/gettext-parser": "8.0.0",

--- a/extract/src/configuration.ts
+++ b/extract/src/configuration.ts
@@ -1,6 +1,6 @@
 import { basename, dirname, extname, join } from "node:path";
 import type { PluralFormsLocale } from "@let-value/translate";
-import type { LevelWithSilent } from "pino";
+import type { LogLevel } from "./logger.ts";
 
 import type { Plugin } from "./plugin.ts";
 import { cleanup } from "./plugins/cleanup/cleanup.ts";
@@ -86,7 +86,7 @@ export interface UserConfig {
      * Log level for the extraction process
      * @default "info"
      */
-    logLevel?: LevelWithSilent;
+    logLevel?: LogLevel;
 }
 
 export interface ResolvedEntrypoint extends Omit<EntrypointConfig, "exclude"> {
@@ -101,7 +101,7 @@ export interface ResolvedConfig {
     destination: DestinationFn;
     obsolete: ObsoleteStrategy;
     walk: boolean;
-    logLevel: LevelWithSilent;
+    logLevel: LogLevel;
     exclude: Exclude[];
 }
 

--- a/extract/src/logger.ts
+++ b/extract/src/logger.ts
@@ -1,16 +1,43 @@
-import pino, { type LevelWithSilent, type Logger } from "pino";
+import chalk from "chalk";
+import log, { type Logger } from "loglevel";
+import prefix from "loglevel-plugin-prefix";
 
-export function createLogger(level: LevelWithSilent = "info"): Logger {
-    return pino({
-        level,
-        transport: {
-            target: "pino-pretty",
-            options: {
-                colorize: true,
-                ignore: "time,pid,hostname",
-            },
+const colors: Record<string, (value: string) => string> = {
+    TRACE: chalk.magenta,
+    DEBUG: chalk.cyan,
+    INFO: chalk.blue,
+    LOG: chalk.blue,
+    WARN: chalk.yellow,
+    ERROR: chalk.red,
+};
+
+let configured = false;
+
+function configure() {
+    if (configured) return;
+
+    prefix.reg(log);
+    log.enableAll();
+
+    prefix.apply(log, {
+        format(level, name, timestamp) {
+            const color = colors[level.toUpperCase()] ?? ((value: string) => value);
+            const scope = name ? ` ${chalk.green(`${name}:`)}` : "";
+            const formattedTimestamp =
+                timestamp instanceof Date ? timestamp.toISOString() : String(timestamp);
+            return `${chalk.gray(`[${formattedTimestamp}]`)} ${color(level)}${scope}`;
         },
     });
+
+    configured = true;
 }
 
-export type { Logger, LevelWithSilent };
+export type LogLevel = "trace" | "debug" | "info" | "warn" | "error" | "silent";
+
+export function createLogger(level: LogLevel = "info"): Logger {
+    configure();
+    log.setLevel(level);
+    return log;
+}
+
+export type { Logger };

--- a/extract/src/logger.ts
+++ b/extract/src/logger.ts
@@ -1,43 +1,26 @@
-import chalk from "chalk";
-import log, { type Logger } from "loglevel";
+import chalk, { type ChalkInstance } from "chalk";
+import log, { type Logger, type LogLevelNames } from "loglevel";
 import prefix from "loglevel-plugin-prefix";
 
-const colors: Record<string, (value: string) => string> = {
-    TRACE: chalk.magenta,
-    DEBUG: chalk.cyan,
-    INFO: chalk.blue,
-    LOG: chalk.blue,
-    WARN: chalk.yellow,
-    ERROR: chalk.red,
+export type LogLevel = LogLevelNames;
+
+const colors: Record<LogLevel, ChalkInstance> = {
+    trace: chalk.magenta,
+    debug: chalk.cyan,
+    info: chalk.blue,
+    warn: chalk.yellow,
+    error: chalk.red,
 };
 
-let configured = false;
+prefix.reg(log);
+prefix.apply(log, {
+    format(level, name) {
+        const color = colors[level as LogLevelNames] ?? ((value: string) => value);
+        const scope = name ? ` ${chalk.green(`${name}:`)}` : "";
 
-function configure() {
-    if (configured) return;
+        return `${color(level)}${scope}`;
+    },
+});
 
-    prefix.reg(log);
-    log.enableAll();
-
-    prefix.apply(log, {
-        format(level, name, timestamp) {
-            const color = colors[level.toUpperCase()] ?? ((value: string) => value);
-            const scope = name ? ` ${chalk.green(`${name}:`)}` : "";
-            const formattedTimestamp =
-                timestamp instanceof Date ? timestamp.toISOString() : String(timestamp);
-            return `${chalk.gray(`[${formattedTimestamp}]`)} ${color(level)}${scope}`;
-        },
-    });
-
-    configured = true;
-}
-
-export type LogLevel = "trace" | "debug" | "info" | "warn" | "error" | "silent";
-
-export function createLogger(level: LogLevel = "info"): Logger {
-    configure();
-    log.setLevel(level);
-    return log;
-}
-
+export const logger = log;
 export type { Logger };

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,12 +40,13 @@
             "version": "1.0.13",
             "dependencies": {
                 "@let-value/translate": "1.0.13",
+                "chalk": "5.3.0",
                 "cosmiconfig": "9.0.0",
                 "gettext-parser": "8.0.0",
                 "glob": "11.0.3",
+                "loglevel": "1.9.1",
+                "loglevel-plugin-prefix": "0.8.4",
                 "oxc-resolver": "11.8.0",
-                "pino": "9.9.5",
-                "pino-pretty": "13.1.1",
                 "plural-forms": "0.5.5",
                 "radash": "12.1.1",
                 "tree-sitter": "0.25.0",
@@ -1171,15 +1172,6 @@
                 "url": "https://github.com/sponsors/sxzz"
             }
         },
-        "node_modules/atomic-sleep": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
-            "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=8.0.0"
-            }
-        },
         "node_modules/base64-js": {
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -1321,6 +1313,18 @@
                 "node": ">=6"
             }
         },
+        "node_modules/chalk": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+            "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+            "license": "MIT",
+            "engines": {
+                "node": "^12.17.0 || ^14.13 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
         "node_modules/chokidar": {
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -1363,12 +1367,6 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "license": "MIT"
-        },
-        "node_modules/colorette": {
-            "version": "2.0.20",
-            "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
-            "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
             "license": "MIT"
         },
         "node_modules/confbox": {
@@ -1442,15 +1440,6 @@
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
             "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
             "license": "MIT"
-        },
-        "node_modules/dateformat": {
-            "version": "4.6.3",
-            "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
-            "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
-            "license": "MIT",
-            "engines": {
-                "node": "*"
-            }
         },
         "node_modules/debug": {
             "version": "4.4.3",
@@ -1559,15 +1548,6 @@
                 "iconv-lite": "^0.6.2"
             }
         },
-        "node_modules/end-of-stream": {
-            "version": "1.4.5",
-            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
-            "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-            "license": "MIT",
-            "dependencies": {
-                "once": "^1.4.0"
-            }
-        },
         "node_modules/env-paths": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
@@ -1619,27 +1599,6 @@
             "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.7.tgz",
             "integrity": "sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==",
             "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/fast-copy": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.2.tgz",
-            "integrity": "sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==",
-            "license": "MIT"
-        },
-        "node_modules/fast-redact": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
-            "integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/fast-safe-stringify": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
-            "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
             "license": "MIT"
         },
         "node_modules/fdir": {
@@ -1745,12 +1704,6 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/help-me": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
-            "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
-            "license": "MIT"
-        },
         "node_modules/hookable": {
             "version": "5.5.3",
             "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
@@ -1852,15 +1805,6 @@
                 "jiti": "lib/jiti-cli.mjs"
             }
         },
-        "node_modules/joycon": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
-            "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -1911,6 +1855,25 @@
             "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
             "license": "MIT"
         },
+        "node_modules/loglevel": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.1.tgz",
+            "integrity": "sha512-hP3I3kCrDIMuRwAwHltphhDM1r8i55H33GgqjXbrisuJhF4kRhW1dNuxsRklp4bXl8DSdLaNLuiL4A/LWRfxvg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6.0"
+            },
+            "funding": {
+                "type": "tidelift",
+                "url": "https://tidelift.com/funding/github/npm/loglevel"
+            }
+        },
+        "node_modules/loglevel-plugin-prefix": {
+            "version": "0.8.4",
+            "resolved": "https://registry.npmjs.org/loglevel-plugin-prefix/-/loglevel-plugin-prefix-0.8.4.tgz",
+            "integrity": "sha512-WpG9CcFAOjz/FtNht+QJeGpvVl/cdR6P0z6OcXSkr8wFJOsV2GRj2j10JLfjuA4aYkcKCNIEqRGCyTife9R8/g==",
+            "license": "MIT"
+        },
         "node_modules/lru-cache": {
             "version": "11.2.1",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.1.tgz",
@@ -1943,15 +1906,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/minimist": {
-            "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-            "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/minipass": {
@@ -2038,24 +1992,6 @@
             "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/on-exit-leak-free": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
-            "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/once": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-            "license": "ISC",
-            "dependencies": {
-                "wrappy": "1"
-            }
         },
         "node_modules/oxc-resolver": {
             "version": "11.8.0",
@@ -2191,67 +2127,6 @@
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
-        "node_modules/pino": {
-            "version": "9.9.5",
-            "resolved": "https://registry.npmjs.org/pino/-/pino-9.9.5.tgz",
-            "integrity": "sha512-d1s98p8/4TfYhsJ09r/Azt30aYELRi6NNnZtEbqFw6BoGsdPVf5lKNK3kUwH8BmJJfpTLNuicjUQjaMbd93dVg==",
-            "license": "MIT",
-            "dependencies": {
-                "atomic-sleep": "^1.0.0",
-                "fast-redact": "^3.1.1",
-                "on-exit-leak-free": "^2.1.0",
-                "pino-abstract-transport": "^2.0.0",
-                "pino-std-serializers": "^7.0.0",
-                "process-warning": "^5.0.0",
-                "quick-format-unescaped": "^4.0.3",
-                "real-require": "^0.2.0",
-                "safe-stable-stringify": "^2.3.1",
-                "sonic-boom": "^4.0.1",
-                "thread-stream": "^3.0.0"
-            },
-            "bin": {
-                "pino": "bin.js"
-            }
-        },
-        "node_modules/pino-abstract-transport": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
-            "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
-            "license": "MIT",
-            "dependencies": {
-                "split2": "^4.0.0"
-            }
-        },
-        "node_modules/pino-pretty": {
-            "version": "13.1.1",
-            "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-13.1.1.tgz",
-            "integrity": "sha512-TNNEOg0eA0u+/WuqH0MH0Xui7uqVk9D74ESOpjtebSQYbNWJk/dIxCXIxFsNfeN53JmtWqYHP2OrIZjT/CBEnA==",
-            "license": "MIT",
-            "dependencies": {
-                "colorette": "^2.0.7",
-                "dateformat": "^4.6.3",
-                "fast-copy": "^3.0.2",
-                "fast-safe-stringify": "^2.1.1",
-                "help-me": "^5.0.0",
-                "joycon": "^3.1.1",
-                "minimist": "^1.2.6",
-                "on-exit-leak-free": "^2.1.0",
-                "pino-abstract-transport": "^2.0.0",
-                "pump": "^3.0.0",
-                "secure-json-parse": "^4.0.0",
-                "sonic-boom": "^4.0.1",
-                "strip-json-comments": "^5.0.2"
-            },
-            "bin": {
-                "pino-pretty": "bin.js"
-            }
-        },
-        "node_modules/pino-std-serializers": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
-            "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==",
-            "license": "MIT"
-        },
         "node_modules/pkg-types": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
@@ -2279,32 +2154,6 @@
                 "node": ">= 0.6.0"
             }
         },
-        "node_modules/process-warning": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
-            "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/fastify"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/fastify"
-                }
-            ],
-            "license": "MIT"
-        },
-        "node_modules/pump": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
-            "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
-            "license": "MIT",
-            "dependencies": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
-            }
-        },
         "node_modules/quansync": {
             "version": "0.2.11",
             "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
@@ -2320,12 +2169,6 @@
                     "url": "https://github.com/sponsors/sxzz"
                 }
             ],
-            "license": "MIT"
-        },
-        "node_modules/quick-format-unescaped": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
-            "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
             "license": "MIT"
         },
         "node_modules/radash": {
@@ -2397,15 +2240,6 @@
             "funding": {
                 "type": "individual",
                 "url": "https://paulmillr.com/funding/"
-            }
-        },
-        "node_modules/real-require": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
-            "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 12.13.0"
             }
         },
         "node_modules/resolve-from": {
@@ -2526,15 +2360,6 @@
             ],
             "license": "MIT"
         },
-        "node_modules/safe-stable-stringify": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
-            "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/safer-buffer": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -2546,22 +2371,6 @@
             "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
             "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
             "license": "MIT"
-        },
-        "node_modules/secure-json-parse": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.0.0.tgz",
-            "integrity": "sha512-dxtLJO6sc35jWidmLxo7ij+Eg48PM/kleBsxpC8QJE0qJICe+KawkDQmvCMZUr9u7WKVHgMW6vy3fQ7zMiFZMA==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/fastify"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/fastify"
-                }
-            ],
-            "license": "BSD-3-Clause"
         },
         "node_modules/semver": {
             "version": "7.7.2",
@@ -2607,24 +2416,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/sonic-boom": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
-            "integrity": "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==",
-            "license": "MIT",
-            "dependencies": {
-                "atomic-sleep": "^1.0.0"
-            }
-        },
-        "node_modules/split2": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
-            "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
-            "license": "ISC",
-            "engines": {
-                "node": ">= 10.x"
             }
         },
         "node_modules/string_decoder": {
@@ -2730,27 +2521,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/strip-json-comments": {
-            "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
-            "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=14.16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/thread-stream": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
-            "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
-            "license": "MIT",
-            "dependencies": {
-                "real-require": "^0.2.0"
             }
         },
         "node_modules/tinyexec": {
@@ -3051,12 +2821,6 @@
             "engines": {
                 "node": ">=8"
             }
-        },
-        "node_modules/wrappy": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-            "license": "ISC"
         },
         "node_modules/yaml": {
             "version": "2.8.1",


### PR DESCRIPTION
## Summary
- replace the Pino logger with a loglevel and chalk based implementation that provides colored prefixes
- update the CLI and configuration types to consume the new log level handling
- update dependencies to remove Pino and add loglevel related packages

## Testing
- npm run typecheck --workspace extract
- npm run test --workspace extract

------
https://chatgpt.com/codex/tasks/task_e_68cc4f297544832fb7f2d0dbb7254e4f