### PR TITLE
Handle deferred plural messages via translate

### DIFF
--- a/e2e/tests/node/app.ts
+++ b/e2e/tests/node/app.ts
@@ -19,8 +19,8 @@ export async function runApp(locale: string, count: number) {
 
     const t = new Translator({ [locale]: translations }).getLocale(locale as never);
 
-    const translated = t.message(deferred);
-    const def = t.message(descriptor);
+    const translated = t.translate(deferred);
+    const def = t.translate(descriptor);
     const greeting = t.message`こんにちは、${name}！`;
     const items = t.ngettext(message`りんご`, message`${count} りんご`, count);
 

--- a/e2e/tests/react/app.tsx
+++ b/e2e/tests/react/app.tsx
@@ -24,8 +24,8 @@ function App({ count }: { count: number }) {
 
     return (
         <div>
-            <div id="translated">{t.message(deferred)}</div>
-            <div id="def">{t.message(descriptor)}</div>
+            <div id="translated">{t.translate(deferred)}</div>
+            <div id="def">{t.translate(descriptor)}</div>
             <div id="greeting">
                 <Message>こんにちは、{name}！</Message>
             </div>

--- a/react/src/components/Message.ts
+++ b/react/src/components/Message.ts
@@ -23,7 +23,9 @@ export function Message({ context, children }: MessageProps) {
 
     const tokens = values.map((_, i) => `\u0000${i}\u0000`);
     const built = message(strings as unknown as TemplateStringsArray, ...tokens);
-    const translated = context ? translator.context(context as "").message(built) : translator.message(built);
+    const translated = context
+        ? translator.translate({ context: context as "", id: built })
+        : translator.translate(built);
 
     // biome-ignore lint/suspicious/noControlCharactersInRegex: using null separators
     const parts = translated.split(/\u0000(\d+)\u0000/);

--- a/react/src/components/Plural.ts
+++ b/react/src/components/Plural.ts
@@ -22,7 +22,9 @@ export function Plural({ number, forms, context }: PluralProps) {
     const messages = built.map((b) => b.message);
     const input = plural(...messages, number);
 
-    const translated = context ? translator.context(context as "").plural(input) : translator.plural(input);
+    const translated = context
+        ? translator.translate({ context: context as "", id: input })
+        : translator.translate(input);
 
     // biome-ignore lint/suspicious/noControlCharactersInRegex: using null separators
     const parts = translated.split(/\u0000(\d+)-(\d+)\u0000/);

--- a/translate/test/translator-context-message.test.ts
+++ b/translate/test/translator-context-message.test.ts
@@ -25,6 +25,16 @@ test("context message returns original string when translation missing", () => {
     assert.equal(t.context("verb").message("Close"), "Close");
 });
 
+test("context message rejects deferred input", () => {
+    const t = new Translator({}).getLocale("en" as never);
+    const verb = context("verb");
+    const deferred = verb.message("Open");
+    assert.throws(() => {
+        // @ts-expect-error context message does not accept deferred inputs
+        t.context("verb").message(deferred);
+    }, /translate\(\)/);
+});
+
 test("pgettext alias works", () => {
     const t = new Translator({}).getLocale("en" as never);
     assert.equal(t.pgettext("ctx", "X"), "X");

--- a/translate/test/translator-context-plural.test.ts
+++ b/translate/test/translator-context-plural.test.ts
@@ -44,6 +44,15 @@ test("context plural returns default forms when translation missing", () => {
     assert.equal(t.context("company").plural(message`${2} pear`, message`${2} pears`, 2), "2 pears");
 });
 
+test("context plural rejects deferred input", () => {
+    const t = new Translator(translations).getLocale("en");
+    const deferred = context("company").plural(message`${1} apple`, message`${1} apples`, 1);
+    assert.throws(() => {
+        // @ts-expect-error context plural does not accept deferred inputs
+        t.context("company").plural(deferred);
+    }, /translate\(\)/);
+});
+
 test("npgettext alias works", () => {
     const t = new Translator(translations).getLocale("en");
     assert.equal(t.npgettext("ctx", message`${1} apple`, message`${1} apples`, 1), "1 apple");

--- a/translate/test/translator-message.test.ts
+++ b/translate/test/translator-message.test.ts
@@ -11,6 +11,15 @@ test("translator substitutes template values", () => {
     assert.equal(t.translate(message`Hello, ${name}!`), "Hello, World!");
 });
 
+test("message rejects deferred message input", () => {
+    const t = new Translator({}).getLocale("en" as never);
+    const deferred = message`Hello`;
+    assert.throws(() => {
+        // @ts-expect-error message does not accept deferred inputs
+        t.message(deferred);
+    }, /translate\(\)/);
+});
+
 test("translator applies translations with placeholders", async () => {
     const name = "World";
     const ruUrl = new URL("./fixtures/ru.po", import.meta.url);

--- a/translate/test/translator-plural.test.ts
+++ b/translate/test/translator-plural.test.ts
@@ -57,6 +57,15 @@ test("translate handles plural helper with multiple forms", () => {
     assert.equal(t.translate(apples), "5 яблок");
 });
 
+test("plural rejects deferred plural input", () => {
+    const t = new Translator(translations).getLocale("en");
+    const apples = plural(message`${1} apple`, message`${1} apples`, 1);
+    assert.throws(() => {
+        // @ts-expect-error plural does not accept deferred inputs
+        t.plural(apples);
+    }, /translate\(\)/);
+});
+
 test("plural substitutes values from the chosen plural form", () => {
     const t = new Translator(translations).getLocale("en");
     assert.equal(t.plural(message`${"Bob"} ${1} carrot`, message`${2} carrots for ${"Bob"}`, 1), "Bob 1 carrot");


### PR DESCRIPTION
## Summary
- allow `LocaleTranslator.translate` to accept deferred plural and context plural messages
- restrict `LocaleTranslator.plural` and context plural helpers to static arguments so deferred calls flow through `translate`
- update plural translator tests to cover the new translate workflow for plural helpers

## Testing
- node --test (from translate/ package)


------
https://chatgpt.com/codex/tasks/task_e_68cec6f2134c832faefb5b189d59fb03