### PR TITLE
feat(extract): dedupe walked files via entrypoint promotion

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,15 +1,15 @@
 {
     "name": "@let-value/translate-e2e",
-    "version": "1.1.1",
+    "version": "1.1.2-beta.1",
     "private": true,
     "type": "module",
     "exports": {
         "./*": "./*"
     },
     "dependencies": {
-        "@let-value/translate": "1.1.1",
-        "@let-value/translate-extract": "1.1.1",
-        "@let-value/translate-react": "1.1.1",
+        "@let-value/translate": "1.1.2-beta.1",
+        "@let-value/translate-extract": "1.1.2-beta.1",
+        "@let-value/translate-react": "1.1.2-beta.1",
         "gettext-parser": "8.0.0",
         "react": "19.1.1",
         "react-dom": "19.1.1"

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,15 +1,15 @@
 {
     "name": "@let-value/translate-e2e",
-    "version": "1.1.2-beta.1",
+    "version": "1.1.2-beta.2",
     "private": true,
     "type": "module",
     "exports": {
         "./*": "./*"
     },
     "dependencies": {
-        "@let-value/translate": "1.1.2-beta.1",
-        "@let-value/translate-extract": "1.1.2-beta.1",
-        "@let-value/translate-react": "1.1.2-beta.1",
+        "@let-value/translate": "1.1.2-beta.2",
+        "@let-value/translate-extract": "1.1.2-beta.2",
+        "@let-value/translate-react": "1.1.2-beta.2",
         "gettext-parser": "8.0.0",
         "react": "19.1.1",
         "react-dom": "19.1.1"

--- a/extract-static/package.json
+++ b/extract-static/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@let-value/translate-extract-static",
-    "version": "1.1.1",
+    "version": "1.1.2-beta.1",
     "type": "module",
     "main": "./dist/src/index.cjs",
     "module": "./dist/src/index.js",
@@ -29,7 +29,7 @@
         "test": "node --test"
     },
     "devDependencies": {
-        "@let-value/translate-extract": "1.1.1",
+        "@let-value/translate-extract": "1.1.2-beta.1",
         "@types/bun": "1.3.8",
         "@types/node": "22.10.2",
         "tsdown": "0.15.2",

--- a/extract-static/package.json
+++ b/extract-static/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@let-value/translate-extract-static",
-    "version": "1.1.2-beta.1",
+    "version": "1.1.2-beta.2",
     "type": "module",
     "main": "./dist/src/index.cjs",
     "module": "./dist/src/index.js",
@@ -29,7 +29,7 @@
         "test": "node --test"
     },
     "devDependencies": {
-        "@let-value/translate-extract": "1.1.2-beta.1",
+        "@let-value/translate-extract": "1.1.2-beta.2",
         "@types/bun": "1.3.8",
         "@types/node": "22.10.2",
         "tsdown": "0.15.2",

--- a/extract/bin/cli.ts
+++ b/extract/bin/cli.ts
@@ -69,12 +69,9 @@ async function main() {
     };
     logger.setLevel(effectiveLogLevel);
 
-    const tasks: Promise<unknown>[] = [];
     for (const entrypoint of config.entrypoints) {
-        tasks.push(run(entrypoint, { config, logger }));
+        await run(entrypoint, { config, logger });
     }
-
-    await Promise.all(tasks);
 }
 
 void main().catch((err) => {

--- a/extract/bin/cli.ts
+++ b/extract/bin/cli.ts
@@ -4,7 +4,7 @@ import { parseArgs } from "node:util";
 import { cosmiconfig } from "cosmiconfig";
 import type { ResolvedConfig } from "../src/configuration.ts";
 import { type LogLevel, logger } from "../src/logger.ts";
-import { run } from "../src/run.ts";
+import { resolveConfiguredEntrypoints, run } from "../src/run.ts";
 
 const moduleName = "translate";
 const defaultLogLevel: LogLevel = "info";
@@ -69,9 +69,11 @@ async function main() {
     };
     logger.setLevel(effectiveLogLevel);
 
+    const entrypoints = await resolveConfiguredEntrypoints(config.entrypoints);
+
     const tasks: Promise<unknown>[] = [];
     for (const entrypoint of config.entrypoints) {
-        tasks.push(run(entrypoint, { config, logger }));
+        tasks.push(run(entrypoint, { config, logger, entrypoints }));
     }
 
     await Promise.all(tasks);

--- a/extract/bin/cli.ts
+++ b/extract/bin/cli.ts
@@ -4,7 +4,7 @@ import { parseArgs } from "node:util";
 import { cosmiconfig } from "cosmiconfig";
 import type { ResolvedConfig } from "../src/configuration.ts";
 import { type LogLevel, logger } from "../src/logger.ts";
-import { resolveConfiguredEntrypoints, run } from "../src/run.ts";
+import { run } from "../src/run.ts";
 
 const moduleName = "translate";
 const defaultLogLevel: LogLevel = "info";
@@ -69,11 +69,9 @@ async function main() {
     };
     logger.setLevel(effectiveLogLevel);
 
-    const entrypoints = await resolveConfiguredEntrypoints(config.entrypoints);
-
     const tasks: Promise<unknown>[] = [];
     for (const entrypoint of config.entrypoints) {
-        tasks.push(run(entrypoint, { config, logger, entrypoints }));
+        tasks.push(run(entrypoint, { config, logger }));
     }
 
     await Promise.all(tasks);

--- a/extract/package.json
+++ b/extract/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@let-value/translate-extract",
-    "version": "1.1.1",
+    "version": "1.1.2-beta.1",
     "type": "module",
     "main": "dist/index.cjs",
     "module": "dist/index.js",
@@ -34,7 +34,7 @@
         "dist"
     ],
     "dependencies": {
-        "@let-value/translate": "1.1.1",
+        "@let-value/translate": "1.1.2-beta.1",
         "chalk": "5.3.0",
         "cosmiconfig": "9.0.0",
         "fast-glob": "3.3.2",

--- a/extract/package.json
+++ b/extract/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@let-value/translate-extract",
-    "version": "1.1.2-beta.1",
+    "version": "1.1.2-beta.2",
     "type": "module",
     "main": "dist/index.cjs",
     "module": "dist/index.js",
@@ -34,7 +34,7 @@
         "dist"
     ],
     "dependencies": {
-        "@let-value/translate": "1.1.2-beta.1",
+        "@let-value/translate": "1.1.2-beta.2",
         "chalk": "5.3.0",
         "cosmiconfig": "9.0.0",
         "fast-glob": "3.3.2",

--- a/extract/src/plugin.ts
+++ b/extract/src/plugin.ts
@@ -7,6 +7,7 @@ type MaybePromise<T> = T | Promise<T>;
 export interface Context {
     config: ResolvedConfig;
     generatedAt: Date;
+    entrypoints: Set<string>;
     logger?: Logger;
 }
 

--- a/extract/src/plugin.ts
+++ b/extract/src/plugin.ts
@@ -7,7 +7,7 @@ type MaybePromise<T> = T | Promise<T>;
 export interface Context {
     config: ResolvedConfig;
     generatedAt: Date;
-    entrypoints: Set<string>;
+    paths: Set<string>;
     logger?: Logger;
 }
 
@@ -64,6 +64,7 @@ export type ProcessHook<TInput = unknown, TOutput = unknown> = (
 
 export interface Build<TInput = unknown, TOutput = unknown> {
     context: Context;
+    source(path: string): void;
     resolve(args: ResolveArgs<unknown>): void;
     load(args: LoadArgs<unknown>): void;
     process(args: ProcessArgs<unknown>): void;

--- a/extract/src/plugins/core/core.ts
+++ b/extract/src/plugins/core/core.ts
@@ -33,16 +33,19 @@ export function core(): Plugin<string, Translation[]> {
             });
 
             build.onProcess({ filter, namespace }, ({ entrypoint, path, data }) => {
-                const { translations, imports, warnings, entrypoint: promotedEntrypoint } = parseSource(data, path);
+                const result = parseSource(data, path);
 
-                if (promotedEntrypoint) {
-                    build.context.entrypoints.add(path);
+                if (result.entrypoint && entrypoint !== path) {
+                    build.source(path);
+                    return;
                 }
+
+                const { translations, imports, warnings } = result;
 
                 if (build.context.config.walk) {
                     const paths = resolveImports(path, imports);
                     for (const path of paths) {
-                        if (build.context.entrypoints.has(path)) {
+                        if (build.context.paths.has(path)) {
                             continue;
                         }
 

--- a/extract/src/plugins/core/core.ts
+++ b/extract/src/plugins/core/core.ts
@@ -33,11 +33,19 @@ export function core(): Plugin<string, Translation[]> {
             });
 
             build.onProcess({ filter, namespace }, ({ entrypoint, path, data }) => {
-                const { translations, imports, warnings } = parseSource(data, path);
+                const { translations, imports, warnings, entrypoint: promotedEntrypoint } = parseSource(data, path);
+
+                if (promotedEntrypoint) {
+                    build.context.entrypoints.add(path);
+                }
 
                 if (build.context.config.walk) {
                     const paths = resolveImports(path, imports);
                     for (const path of paths) {
+                        if (build.context.entrypoints.has(path)) {
+                            continue;
+                        }
+
                         build.resolve({ entrypoint, path, namespace });
                     }
                 }

--- a/extract/src/plugins/core/core.ts
+++ b/extract/src/plugins/core/core.ts
@@ -14,6 +14,7 @@ export function core(): Plugin<string, Translation[]> {
         name: "core",
         setup(build) {
             build.context.logger?.debug("core plugin initialized");
+
             build.onResolve({ filter, namespace }, ({ entrypoint, path }) => {
                 return {
                     entrypoint,
@@ -37,7 +38,7 @@ export function core(): Plugin<string, Translation[]> {
 
                 if (result.entrypoint && entrypoint !== path) {
                     build.source(path);
-                    return;
+                    return { entrypoint, path, namespace, data: [] as Translation[] };
                 }
 
                 const { translations, imports, warnings } = result;

--- a/extract/src/plugins/core/queries/comment.ts
+++ b/extract/src/plugins/core/queries/comment.ts
@@ -9,7 +9,7 @@ export function getReference(node: Parser.SyntaxNode, { path }: Context) {
     return `${rel}:${line}`;
 }
 
-function getComment(node: Parser.SyntaxNode): string {
+export function getComment(node: Parser.SyntaxNode): string {
     const text = node.text;
     if (text.startsWith("/*")) {
         return text

--- a/extract/src/plugins/core/queries/context.ts
+++ b/extract/src/plugins/core/queries/context.ts
@@ -48,8 +48,7 @@ export const contextMsgQuery: QuerySpec = withComment({
             }
         }
 
-        const contextText =
-            contextNode.type === "template_string" ? contextNode.text.slice(1, -1) : contextNode.text;
+        const contextText = contextNode.type === "template_string" ? contextNode.text.slice(1, -1) : contextNode.text;
         return {
             node: result.node,
             translation: {

--- a/extract/src/plugins/core/queries/entrypoint.ts
+++ b/extract/src/plugins/core/queries/entrypoint.ts
@@ -1,0 +1,14 @@
+import type Parser from "@keqingmoe/tree-sitter";
+import { getComment } from "./comment.ts";
+import type { EntrypointSpec } from "./types.ts";
+
+const entrypointCommentPattern = /(?:^|\s)@?translate-entrypoint(?:\s|$)/;
+
+export const entrypointQuery: EntrypointSpec = {
+    pattern: `(comment) @comment`,
+    extract(match: Parser.QueryMatch): boolean | undefined {
+        return match.captures
+            .filter((capture) => capture.name === "comment")
+            .some((capture) => entrypointCommentPattern.test(getComment(capture.node)));
+    },
+};

--- a/extract/src/plugins/core/queries/types.ts
+++ b/extract/src/plugins/core/queries/types.ts
@@ -32,6 +32,11 @@ export interface Context {
     path: string;
 }
 
+export interface EntrypointSpec {
+    pattern: string;
+    extract(match: Parser.QueryMatch): boolean | undefined;
+}
+
 export interface QuerySpec {
     pattern: string;
     extract(match: Parser.QueryMatch): MessageMatch | undefined;

--- a/extract/src/plugins/core/tests/context-template.test.ts
+++ b/extract/src/plugins/core/tests/context-template.test.ts
@@ -27,3 +27,17 @@ test("extracts context from tagged template builder alongside plain message", ()
         { id: "Sign out", context: undefined },
     ]);
 });
+
+test("detects magic comment entrypoint promotion", () => {
+    const source = [
+        'import { message } from "@let-value/translate";',
+        "",
+        "/* translate-entrypoint */",
+        'message("Hello");',
+        "",
+    ].join("\n");
+
+    const result = parseSource(source, "/project/example.ts");
+
+    assert.equal(result.entrypoint, true);
+});

--- a/extract/src/plugins/po/collect.ts
+++ b/extract/src/plugins/po/collect.ts
@@ -5,7 +5,7 @@ import type { Translation } from "../core/queries/types.ts";
 
 export function collect(source: Translation[], locale?: string): GetTextTranslationRecord {
     const translations: GetTextTranslationRecord = { "": {} };
-    const nplurals = locale ? getNPlurals(locale) : undefined;
+    const nplurals = locale ? Number(getNPlurals(locale)) : undefined;
 
     for (const { context, id, message, comments, obsolete, plural } of source) {
         const ctx = context || "";

--- a/extract/src/plugins/po/merge.ts
+++ b/extract/src/plugins/po/merge.ts
@@ -31,7 +31,7 @@ export function merge(
     let headers: Record<string, string> = {};
     let translations: GetTextTranslationRecord = { "": {} };
     let obsoleteTranslations: GetTextTranslationRecord = {};
-    const nplurals = getNPlurals(locale);
+    const nplurals = Number(getNPlurals(locale));
 
     if (existing) {
         headers = existing.headers ? structuredClone(existing.headers) : {};

--- a/extract/src/plugins/react/react.ts
+++ b/extract/src/plugins/react/react.ts
@@ -1,6 +1,3 @@
-import { readFile } from "node:fs/promises";
-import { resolve } from "node:path";
-
 import type { Plugin } from "../../plugin.ts";
 import type { Translation } from "../core/queries/types.ts";
 import { parseSource } from "./parse.ts";
@@ -12,22 +9,6 @@ export function react(): Plugin<string, Translation[]> {
         name: "react",
         setup(build) {
             build.context.logger?.debug("react plugin initialized");
-            build.onResolve({ filter: /.*/, namespace: "source" }, ({ entrypoint, path, namespace }) => {
-                return {
-                    entrypoint,
-                    namespace,
-                    path: resolve(path),
-                };
-            });
-            build.onLoad({ filter, namespace: "source" }, async ({ entrypoint, path, namespace }) => {
-                const data = await readFile(path, "utf8");
-                return {
-                    entrypoint,
-                    path,
-                    namespace,
-                    data,
-                };
-            });
             build.onProcess({ filter, namespace: "source" }, ({ entrypoint, path, data }) => {
                 const { translations, warnings } = parseSource(data, path);
 

--- a/extract/src/run.ts
+++ b/extract/src/run.ts
@@ -45,6 +45,7 @@ export async function run(
     const exclude = entrypoint.exclude ?? config.exclude;
     const walk = entrypoint.walk ?? config.walk;
     const paths = new Set<string>();
+    const resolved = new Set<string>();
 
     const context: Context = {
         config: { ...config, destination, obsolete, exclude, walk },
@@ -96,8 +97,16 @@ export async function run(
 
     function resolve(args: ResolveArgs) {
         const { entrypoint, path, namespace } = args;
+        const key = `${entrypoint}:${namespace}:${path}`;
+
+        const visited = resolved.has(key);
         const skipped = context.config.exclude.some((ex) => (typeof ex === "function" ? ex(args) : ex.test(args.path)));
-        logger?.debug({ entrypoint, path, namespace, skipped }, "resolve");
+        logger?.debug({ entrypoint, path, namespace, skipped, visited }, "resolve");
+
+        if (namespace === "source" && visited) {
+            return;
+        }
+        resolved.add(key);
 
         if (skipped) {
             return;
@@ -164,6 +173,7 @@ export async function run(
             const result = await hook(args as never);
             if (result !== undefined) {
                 args = result as never;
+                break;
             }
         }
 

--- a/extract/src/tests/run.test.ts
+++ b/extract/src/tests/run.test.ts
@@ -6,7 +6,7 @@ import { test } from "node:test";
 
 import { defineConfig } from "../configuration.ts";
 import type { Plugin } from "../plugin.ts";
-import { run } from "../run.ts";
+import { resolveConfiguredEntrypoints, run } from "../run.ts";
 
 test("runs all process hooks for a file", async () => {
     const entrypoint = "dummy.tsx";
@@ -120,4 +120,115 @@ test("resolves glob entrypoints to matched files", async () => {
     await run(config.entrypoints[0], { config });
 
     assert.deepEqual(seen, [file]);
+});
+
+test("expands configured entrypoint globs before running extraction", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "translate-extract-"));
+    const pageA = join(directory, "page-a.ts");
+    const pageB = join(directory, "page-b.ts");
+    await writeFile(pageA, "export const a = 1;\n");
+    await writeFile(pageB, "export const b = 1;\n");
+
+    const config = defineConfig({ entrypoints: join(directory, "**/*.ts").replaceAll("\\", "/") });
+    const entrypoints = await resolveConfiguredEntrypoints(config.entrypoints);
+
+    assert.deepEqual(Array.from(entrypoints).sort(), [resolve(pageA), resolve(pageB)]);
+});
+
+test("does not walk into files that are configured as entrypoints", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "translate-extract-"));
+    const pageA = join(directory, "page-a.ts");
+    const pageB = join(directory, "page-b.ts");
+    const component = join(directory, "component.ts");
+
+    await writeFile(
+        pageA,
+        `import "./component";
+export const a = 1;
+`,
+    );
+    await writeFile(
+        pageB,
+        `import "./component";
+export const b = 1;
+`,
+    );
+    await writeFile(
+        component,
+        `export const component = "shared";
+`,
+    );
+
+    const seenSourcePaths: string[] = [];
+
+    const plugin: Plugin = {
+        name: "source-spy",
+        setup(build) {
+            build.onResolve({ filter: /.*/, namespace: "source" }, (args) => {
+                seenSourcePaths.push(resolve(args.path));
+                return args;
+            });
+        },
+    };
+
+    const config = defineConfig({
+        entrypoints: [pageA, pageB, component],
+        plugins: ({ core }) => [core(), plugin],
+    });
+
+    const entrypoints = new Set([resolve(pageA), resolve(pageB), resolve(component)]);
+    await run(config.entrypoints[0], { config, entrypoints });
+
+    assert.deepEqual(seenSourcePaths, [resolve(pageA)]);
+});
+
+test("promotes files with magic comment to entrypoints and skips duplicate walks", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "translate-extract-"));
+    const pageA = join(directory, "page-a.ts");
+    const pageB = join(directory, "page-b.ts");
+    const component = join(directory, "component.ts");
+
+    await writeFile(
+        pageA,
+        `import "./component";
+export const a = 1;
+`,
+    );
+    await writeFile(
+        pageB,
+        `import "./component";
+export const b = 1;
+`,
+    );
+    await writeFile(
+        component,
+        `// translate-entrypoint
+export const component = "shared";
+`,
+    );
+
+    const seenSourcePaths: string[] = [];
+
+    const plugin: Plugin = {
+        name: "source-spy",
+        setup(build) {
+            build.onResolve({ filter: /.*/, namespace: "source" }, (args) => {
+                seenSourcePaths.push(resolve(args.path));
+                return args;
+            });
+        },
+    };
+
+    const config = defineConfig({
+        entrypoints: [pageA, pageB],
+        plugins: ({ core }) => [core(), plugin],
+    });
+
+    const entrypoints = new Set([resolve(pageA), resolve(pageB)]);
+
+    await run(config.entrypoints[0], { config, entrypoints });
+    await run(config.entrypoints[1], { config, entrypoints });
+
+    assert.deepEqual(seenSourcePaths, [resolve(pageA), resolve(component), resolve(pageB)]);
+    assert.equal(entrypoints.has(resolve(component)), true);
 });

--- a/extract/src/tests/run.test.ts
+++ b/extract/src/tests/run.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { test } from "node:test";
@@ -19,9 +19,9 @@ test("runs all process hooks for a file", async () => {
         setup(build) {
             build.onResolve({ filter: /.*/, namespace: "source" }, (args) => args);
             build.onLoad({ filter: /.*/, namespace: "source" }, (args) => ({ ...args, data: "" }));
-            build.onProcess({ filter: /.*/, namespace: "source" }, (args) => {
+            build.onProcess({ filter: /.*/, namespace: "source" }, () => {
                 collected.push(coreTranslations);
-                return { ...args, data: coreTranslations };
+                return undefined;
             });
         },
     };
@@ -29,20 +29,9 @@ test("runs all process hooks for a file", async () => {
     const reactPlugin: Plugin = {
         name: "react-plugin",
         setup(build) {
-            build.onResolve({ filter: /.*/, namespace: "source" }, ({ entrypoint, path, namespace }) => ({
-                entrypoint,
-                path,
-                namespace,
-            }));
-            build.onLoad({ filter: /.*/, namespace: "source" }, ({ entrypoint, path, namespace }) => ({
-                entrypoint,
-                path,
-                namespace,
-                data: "",
-            }));
-            build.onProcess({ filter: /.*/, namespace: "source" }, (args) => {
+            build.onProcess({ filter: /.*/, namespace: "source" }, () => {
                 collected.push(reactTranslations);
-                return { ...args, data: reactTranslations };
+                return undefined;
             });
         },
     };
@@ -153,14 +142,14 @@ export const b = 1;
         setup(build) {
             build.onResolve({ filter: /.*/, namespace: "source" }, (args) => {
                 seenSourcePaths.push(resolve(args.path));
-                return args;
+                return undefined;
             });
         },
     };
 
     const config = defineConfig({
         entrypoints: [pageA, pageB, component],
-        plugins: ({ core }) => [core(), plugin],
+        plugins: ({ core }) => [plugin, core()],
     });
 
     await run(config.entrypoints[0], { config });
@@ -205,14 +194,14 @@ export const component = "shared";
             build.onResolve({ filter: /.*/, namespace: "source" }, (args) => {
                 seenResolves.push(args);
                 seenSourcePaths.push(resolve(args.path));
-                return args;
+                return undefined;
             });
         },
     };
 
     const config = defineConfig({
         entrypoints: [pageA, pageB],
-        plugins: [plugin],
+        plugins: ({ core, po, cleanup }) => [plugin, core(), po(), cleanup()],
     });
 
     await run(config.entrypoints[0], { config });
@@ -320,4 +309,86 @@ message("component");
     assert.equal(componentPo.includes('msgid "component"'), true);
     assert.equal(componentPo.includes('msgid "page-a"'), false);
     assert.equal(componentPo.includes('msgid "page-b"'), false);
+});
+
+test("terminates when walked children have circular imports", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "translate-extract-"));
+    const page = join(directory, "page.ts");
+    const childA = join(directory, "child-a.ts");
+    const childB = join(directory, "child-b.ts");
+
+    await writeFile(
+        page,
+        `import "./child-a";
+message("page");
+`,
+    );
+    await writeFile(
+        childA,
+        `import "./child-b";
+export const a = 1;
+`,
+    );
+    await writeFile(
+        childB,
+        `import "./child-a";
+export const b = 2;
+`,
+    );
+
+    const config = defineConfig({ entrypoints: page });
+    await run(config.entrypoints[0], { config });
+
+    const pagePo = await readFile(join(directory, "translations", "page.en.po"), "utf8");
+    assert.equal(pagePo.includes('msgid "page"'), true);
+});
+
+test("terminates when promoted entrypoint children have circular imports", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "translate-extract-"));
+    const componentsDir = join(directory, "components");
+    await mkdir(componentsDir, { recursive: true });
+
+    const page = join(directory, "page.ts");
+    const menu = join(componentsDir, "menu.ts");
+    const childA = join(componentsDir, "child-a.ts");
+    const childB = join(componentsDir, "child-b.ts");
+
+    await writeFile(
+        page,
+        `import "./components/menu";
+message("page");
+`,
+    );
+    await writeFile(
+        menu,
+        `// translate-entrypoint
+import "./child-a";
+import "./child-b";
+message("menu");
+`,
+    );
+    await writeFile(
+        childA,
+        `import "./child-b";
+export const a = 1;
+`,
+    );
+    await writeFile(
+        childB,
+        `import "./child-a";
+export const b = 2;
+`,
+    );
+
+    const config = defineConfig({ entrypoints: page });
+    await run(config.entrypoints[0], { config });
+
+    const pagePo = await readFile(join(directory, "translations", "page.en.po"), "utf8");
+    const menuPo = await readFile(join(componentsDir, "translations", "menu.en.po"), "utf8");
+
+    assert.equal(pagePo.includes('msgid "page"'), true);
+    assert.equal(pagePo.includes('msgid "menu"'), false);
+
+    assert.equal(menuPo.includes('msgid "menu"'), true);
+    assert.equal(menuPo.includes('msgid "page"'), false);
 });

--- a/loader/package.json
+++ b/loader/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@let-value/translate-loader",
-    "version": "1.1.1",
+    "version": "1.1.2-beta.1",
     "type": "module",
     "main": "dist/index.cjs",
     "module": "dist/index.js",

--- a/loader/package.json
+++ b/loader/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@let-value/translate-loader",
-    "version": "1.1.2-beta.1",
+    "version": "1.1.2-beta.2",
     "type": "module",
     "main": "dist/index.cjs",
     "module": "dist/index.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "translate",
-    "version": "1.1.1",
+    "version": "1.1.2-beta.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "translate",
-            "version": "1.1.1",
+            "version": "1.1.2-beta.1",
             "workspaces": [
                 "loader",
                 "translate",
@@ -26,11 +26,11 @@
         },
         "e2e": {
             "name": "@let-value/translate-e2e",
-            "version": "1.1.1",
+            "version": "1.1.2-beta.1",
             "dependencies": {
-                "@let-value/translate": "1.1.1",
-                "@let-value/translate-extract": "1.1.1",
-                "@let-value/translate-react": "1.1.1",
+                "@let-value/translate": "1.1.2-beta.1",
+                "@let-value/translate-extract": "1.1.2-beta.1",
+                "@let-value/translate-react": "1.1.2-beta.1",
                 "gettext-parser": "8.0.0",
                 "react": "19.1.1",
                 "react-dom": "19.1.1"
@@ -38,10 +38,10 @@
         },
         "extract": {
             "name": "@let-value/translate-extract",
-            "version": "1.1.1",
+            "version": "1.1.2-beta.1",
             "dependencies": {
                 "@keqingmoe/tree-sitter": "0.26.2",
-                "@let-value/translate": "1.1.1",
+                "@let-value/translate": "1.1.2-beta.1",
                 "chalk": "5.3.0",
                 "cosmiconfig": "9.0.0",
                 "fast-glob": "3.3.2",
@@ -64,7 +64,7 @@
         },
         "extract-static": {
             "name": "@let-value/translate-extract-static",
-            "version": "1.1.1",
+            "version": "1.1.2-beta.1",
             "hasInstallScript": true,
             "dependencies": {
                 "detect-libc": "2.1.2"
@@ -73,7 +73,7 @@
                 "extract": "dist/bin/cli.js"
             },
             "devDependencies": {
-                "@let-value/translate-extract": "1.1.1",
+                "@let-value/translate-extract": "1.1.2-beta.1",
                 "@types/bun": "1.3.8",
                 "@types/node": "22.10.2",
                 "tsdown": "0.15.2",
@@ -151,7 +151,7 @@
         },
         "loader": {
             "name": "@let-value/translate-loader",
-            "version": "1.1.1",
+            "version": "1.1.2-beta.1",
             "dependencies": {
                 "gettext-parser": "8.0.0",
                 "unplugin": "2.3.10"
@@ -2660,12 +2660,12 @@
         },
         "react": {
             "name": "@let-value/translate-react",
-            "version": "1.1.1",
+            "version": "1.1.2-beta.1",
             "dependencies": {
-                "@let-value/translate": "1.1.1"
+                "@let-value/translate": "1.1.2-beta.1"
             },
             "devDependencies": {
-                "@let-value/translate-e2e": "1.1.1",
+                "@let-value/translate-e2e": "1.1.2-beta.1",
                 "@types/gettext-parser": "8.0.0",
                 "@types/react": "19.1.13",
                 "@types/react-dom": "19.1.9",
@@ -2680,7 +2680,7 @@
         },
         "translate": {
             "name": "@let-value/translate",
-            "version": "1.1.1",
+            "version": "1.1.2-beta.1",
             "dependencies": {
                 "plural-forms": "0.5.5"
             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "translate",
-    "version": "1.1.2-beta.1",
+    "version": "1.1.2-beta.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "translate",
-            "version": "1.1.2-beta.1",
+            "version": "1.1.2-beta.2",
             "workspaces": [
                 "loader",
                 "translate",
@@ -26,11 +26,11 @@
         },
         "e2e": {
             "name": "@let-value/translate-e2e",
-            "version": "1.1.2-beta.1",
+            "version": "1.1.2-beta.2",
             "dependencies": {
-                "@let-value/translate": "1.1.2-beta.1",
-                "@let-value/translate-extract": "1.1.2-beta.1",
-                "@let-value/translate-react": "1.1.2-beta.1",
+                "@let-value/translate": "1.1.2-beta.2",
+                "@let-value/translate-extract": "1.1.2-beta.2",
+                "@let-value/translate-react": "1.1.2-beta.2",
                 "gettext-parser": "8.0.0",
                 "react": "19.1.1",
                 "react-dom": "19.1.1"
@@ -38,10 +38,10 @@
         },
         "extract": {
             "name": "@let-value/translate-extract",
-            "version": "1.1.2-beta.1",
+            "version": "1.1.2-beta.2",
             "dependencies": {
                 "@keqingmoe/tree-sitter": "0.26.2",
-                "@let-value/translate": "1.1.2-beta.1",
+                "@let-value/translate": "1.1.2-beta.2",
                 "chalk": "5.3.0",
                 "cosmiconfig": "9.0.0",
                 "fast-glob": "3.3.2",
@@ -64,7 +64,7 @@
         },
         "extract-static": {
             "name": "@let-value/translate-extract-static",
-            "version": "1.1.2-beta.1",
+            "version": "1.1.2-beta.2",
             "hasInstallScript": true,
             "dependencies": {
                 "detect-libc": "2.1.2"
@@ -73,7 +73,7 @@
                 "extract": "dist/bin/cli.js"
             },
             "devDependencies": {
-                "@let-value/translate-extract": "1.1.2-beta.1",
+                "@let-value/translate-extract": "1.1.2-beta.2",
                 "@types/bun": "1.3.8",
                 "@types/node": "22.10.2",
                 "tsdown": "0.15.2",
@@ -151,7 +151,7 @@
         },
         "loader": {
             "name": "@let-value/translate-loader",
-            "version": "1.1.2-beta.1",
+            "version": "1.1.2-beta.2",
             "dependencies": {
                 "gettext-parser": "8.0.0",
                 "unplugin": "2.3.10"
@@ -2660,12 +2660,12 @@
         },
         "react": {
             "name": "@let-value/translate-react",
-            "version": "1.1.2-beta.1",
+            "version": "1.1.2-beta.2",
             "dependencies": {
-                "@let-value/translate": "1.1.2-beta.1"
+                "@let-value/translate": "1.1.2-beta.2"
             },
             "devDependencies": {
-                "@let-value/translate-e2e": "1.1.2-beta.1",
+                "@let-value/translate-e2e": "1.1.2-beta.2",
                 "@types/gettext-parser": "8.0.0",
                 "@types/react": "19.1.13",
                 "@types/react-dom": "19.1.9",
@@ -2680,7 +2680,7 @@
         },
         "translate": {
             "name": "@let-value/translate",
-            "version": "1.1.2-beta.1",
+            "version": "1.1.2-beta.2",
             "dependencies": {
                 "plural-forms": "0.5.5"
             },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "translate",
-    "version": "1.1.1",
+    "version": "1.1.2-beta.1",
     "type": "module",
     "private": true,
     "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "translate",
-    "version": "1.1.2-beta.1",
+    "version": "1.1.2-beta.2",
     "type": "module",
     "private": true,
     "workspaces": [

--- a/react/package.json
+++ b/react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@let-value/translate-react",
-    "version": "1.1.1",
+    "version": "1.1.2-beta.1",
     "type": "module",
     "main": "dist/index.cjs",
     "module": "dist/index.js",
@@ -24,10 +24,10 @@
         "test": "node --test"
     },
     "dependencies": {
-        "@let-value/translate": "1.1.1"
+        "@let-value/translate": "1.1.2-beta.1"
     },
     "devDependencies": {
-        "@let-value/translate-e2e": "1.1.1",
+        "@let-value/translate-e2e": "1.1.2-beta.1",
         "@types/gettext-parser": "8.0.0",
         "@types/react": "19.1.13",
         "@types/react-dom": "19.1.9",

--- a/react/package.json
+++ b/react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@let-value/translate-react",
-    "version": "1.1.2-beta.1",
+    "version": "1.1.2-beta.2",
     "type": "module",
     "main": "dist/index.cjs",
     "module": "dist/index.js",
@@ -24,10 +24,10 @@
         "test": "node --test"
     },
     "dependencies": {
-        "@let-value/translate": "1.1.2-beta.1"
+        "@let-value/translate": "1.1.2-beta.2"
     },
     "devDependencies": {
-        "@let-value/translate-e2e": "1.1.2-beta.1",
+        "@let-value/translate-e2e": "1.1.2-beta.2",
         "@types/gettext-parser": "8.0.0",
         "@types/react": "19.1.13",
         "@types/react-dom": "19.1.9",

--- a/translate/package.json
+++ b/translate/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@let-value/translate",
-    "version": "1.1.1",
+    "version": "1.1.2-beta.1",
     "type": "module",
     "main": "dist/index.cjs",
     "module": "dist/index.js",

--- a/translate/package.json
+++ b/translate/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@let-value/translate",
-    "version": "1.1.2-beta.1",
+    "version": "1.1.2-beta.2",
     "type": "module",
     "main": "dist/index.cjs",
     "module": "dist/index.js",


### PR DESCRIPTION
### Motivation
- Prevent duplicated translation extraction when the same component is reachable both as a page import and as a configured entrypoint. 
- Provide a way for authors to opt files into entrypoint semantics via an in-source magic comment so walkers can stop resolving into those files. 
- Ensure entrypoint expansion happens first so the walk/task queue can avoid duplicate parse/load tasks across runs.

### Description
- Add `entrypoints: Set<string>` to the build `Context` so the walker and plugins can consult a shared set of active entrypoints. 
- Add `resolveConfiguredEntrypoints()` and normalize/expand configured globs in `run` so configured entrypoints are pre-resolved and passed to each `run()` invocation via an `entrypoints` parameter. 
- Update `core` plugin: parse now returns `entrypoint: boolean` for magic-comment promotion, the `core` plugin promotes files with the magic comment into the shared entrypoint set, and the import-walking step skips resolving imports that are in the entrypoint set. 
- Extend parser to detect `translate-entrypoint`/`@translate-entrypoint` in comments and expose `getComment()` to reuse comment extraction logic. 
- Update CLI to call `resolveConfiguredEntrypoints()` and pass the shared set into each extraction run. 
- Add tests for glob pre-expansion, dedupe when imports are configured entrypoints, magic-comment promotion across runs, and parser-level magic-comment detection (`extract/src/tests/run.test.ts`, `extract/src/plugins/core/tests/context-template.test.ts`). 

### Testing
- Ran formatting and lint checks: `npm run -w extract format` and `npm run -w extract check` (both completed successfully). 
- Ran targeted test files: `node --test extract/src/tests/run.test.ts extract/src/plugins/core/tests/context-template.test.ts` (passed). 
- Ran full package tests: `npm run -w extract test` and all tests passed (no failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b755ce5f8832fafcc67c019d91c3b)