### PR TITLE
fix(extract): dedupe queued tasks to prevent resolve/load/process loops

### DIFF
--- a/extract/src/run.ts
+++ b/extract/src/run.ts
@@ -66,6 +66,11 @@ export async function run(
 
     const pending = new Map<string, Defer>();
     const queue: Task[] = [];
+    const seen = new Set<string>();
+
+    function getTaskKey(type: Task["type"], args: ResolveArgs | LoadArgs | ProcessArgs) {
+        return `${type}:${args.namespace}:${args.entrypoint}:${args.path}`;
+    }
 
     function getDeferred(namespace: string) {
         let defer = pending.get(namespace);
@@ -96,20 +101,31 @@ export async function run(
 
     function resolve(args: ResolveArgs) {
         const { entrypoint, path, namespace } = args;
+        const key = getTaskKey("resolve", args);
         const skipped = context.config.exclude.some((ex) => (typeof ex === "function" ? ex(args) : ex.test(args.path)));
-        logger?.debug({ entrypoint, path, namespace, skipped }, "resolve");
+        const duplicate = seen.has(key);
+        logger?.debug({ entrypoint, path, namespace, skipped, duplicate }, "resolve");
 
-        if (skipped) {
+        if (skipped || duplicate) {
             return;
         }
 
+        seen.add(key);
         queue.push({ type: "resolve", args });
         getDeferred(namespace).enqueue();
     }
 
     function load(args: LoadArgs) {
         const { entrypoint, path, namespace } = args;
-        logger?.debug({ entrypoint, path, namespace }, "load");
+        const key = getTaskKey("load", args);
+        const duplicate = seen.has(key);
+        logger?.debug({ entrypoint, path, namespace, duplicate }, "load");
+
+        if (duplicate) {
+            return;
+        }
+
+        seen.add(key);
 
         queue.push({ type: "load", args });
         getDeferred(namespace).enqueue();
@@ -117,7 +133,15 @@ export async function run(
 
     function process(args: ProcessArgs) {
         const { entrypoint, path, namespace } = args;
-        logger?.debug({ entrypoint, path, namespace }, "process");
+        const key = getTaskKey("process", args);
+        const duplicate = seen.has(key);
+        logger?.debug({ entrypoint, path, namespace, duplicate }, "process");
+
+        if (duplicate) {
+            return;
+        }
+
+        seen.add(key);
 
         queue.push({ type: "process", args });
         getDeferred(namespace).enqueue();

--- a/extract/src/tests/run.test.ts
+++ b/extract/src/tests/run.test.ts
@@ -321,3 +321,42 @@ message("component");
     assert.equal(componentPo.includes('msgid "page-a"'), false);
     assert.equal(componentPo.includes('msgid "page-b"'), false);
 });
+
+test("deduplicates repeated tasks to avoid resolve/load/process loops", { timeout: 1000 }, async () => {
+    const entrypoint = "loop.ts";
+    let resolveCalls = 0;
+    let loadCalls = 0;
+    let processCalls = 0;
+
+    const plugin: Plugin = {
+        name: "loop-plugin",
+        setup(build) {
+            build.onResolve({ filter: /.*/, namespace: "source" }, (args) => {
+                resolveCalls += 1;
+                return args;
+            });
+
+            build.onLoad({ filter: /.*/, namespace: "source" }, (args) => {
+                loadCalls += 1;
+                return { ...args, data: "" };
+            });
+
+            build.onProcess({ filter: /.*/, namespace: "source" }, (args) => {
+                processCalls += 1;
+                build.resolve({
+                    entrypoint: args.entrypoint,
+                    path: args.path,
+                    namespace: args.namespace,
+                });
+                return undefined;
+            });
+        },
+    };
+
+    const config = defineConfig({ entrypoints: entrypoint, plugins: () => [plugin] });
+    await run(config.entrypoints[0], { config });
+
+    assert.equal(resolveCalls, 1);
+    assert.equal(loadCalls, 1);
+    assert.equal(processCalls, 1);
+});


### PR DESCRIPTION
### Motivation
- CI traces showed repeated `resolve`/`load` cycles for the same `(namespace, path)` combinations, which can produce non-terminating extraction runs when plugins re-enqueue identical work. 
- The runner must avoid re-scheduling identical tasks within a single run to guarantee termination while preserving normal traversal semantics.

### Description
- Add a `seen` set and `getTaskKey` helper to `extract/src/run.ts` and use it to deduplicate `resolve`, `load`, and `process` enqueueing by `(type, namespace, entrypoint, path)`.
- Short-circuit duplicate scheduling in `resolve`, `load`, and `process` and emit `duplicate` metadata in debug logs to surface repeated scheduling in CI traces.
- Add a regression test `deduplicates repeated tasks to avoid resolve/load/process loops` in `extract/src/tests/run.test.ts` that intentionally re-enqueues the same `source` task and asserts the pipeline runs exactly one resolve/load/process pass.

### Testing
- Ran code formatting with `npm run format --workspace extract` and it completed successfully. 
- Ran the package tests with `npm run test --workspace extract` and the suite passed (`# tests 139`, `# pass 139`, `# fail 0`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad5d9f5420832facc9de3f5f8c9988)