### PR TITLE
[codex] Configure npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,18 @@ jobs:
           scope: '@let-value'
       - run: npm ci
       - run: npm run build
-      - run: npm publish --workspaces --access public
+      - name: Resolve npm publish tag
+        id: npm-publish-tag
+        shell: bash
+        run: |
+          version="$(node -p "require('./package.json').version")"
+          prerelease="${version#*-}"
+          if [ "$prerelease" = "$version" ]; then
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${prerelease%%.*}" >> "$GITHUB_OUTPUT"
+          fi
+      - run: npm publish --workspaces --access public --tag ${{ steps.npm-publish-tag.outputs.tag }}
         env:
           NODE_AUTH_TOKEN: ${{ github.token }}
 
@@ -69,4 +80,15 @@ jobs:
           registry-url: https://registry.npmjs.org
       - run: npm ci
       - run: npm run build
-      - run: npm publish --workspaces --access public
+      - name: Resolve npm publish tag
+        id: npm-publish-tag
+        shell: bash
+        run: |
+          version="$(node -p "require('./package.json').version")"
+          prerelease="${version#*-}"
+          if [ "$prerelease" = "$version" ]; then
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${prerelease%%.*}" >> "$GITHUB_OUTPUT"
+          fi
+      - run: npm publish --workspaces --access public --tag ${{ steps.npm-publish-tag.outputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,11 +19,11 @@ jobs:
           - runner: macos-15-intel
           - runner: macos-15
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
-          cache: npm
+          package-manager-cache: false
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.8
@@ -36,32 +36,37 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
-  publish:
+  publish-github-packages:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
-    strategy:
-      matrix:
-        registry: [
-          { enabled: true, public: true, url: 'https://npm.pkg.github.com', token: GITHUB_TOKEN,  },
-          { enabled: true, public: true, url: 'https://registry.npmjs.org', token: NPM_TOKEN,  },
-        ]
-      fail-fast: false
     steps:
-      - name: Early exit
-        if: matrix.registry.enabled == false
-        run: exit 1
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
-          cache: npm
-          registry-url: ${{ matrix.registry.url }}
+          package-manager-cache: false
+          registry-url: https://npm.pkg.github.com
           scope: '@let-value'
-          token: ${{ secrets[matrix.registry.token] }}
       - run: npm ci
       - run: npm run build
-      - run: npm publish --workspaces --access ${{ matrix.registry.public && 'public' || 'restricted' }}
+      - run: npm publish --workspaces --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets[matrix.registry.token] }}
+          NODE_AUTH_TOKEN: ${{ github.token }}
+
+  publish-npm:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          package-manager-cache: false
+          registry-url: https://registry.npmjs.org
+      - run: npm ci
+      - run: npm run build
+      - run: npm publish --workspaces --access public

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,15 +1,15 @@
 {
     "name": "@let-value/translate-e2e",
-    "version": "1.1.5-beta.2",
+    "version": "1.1.5-beta.3",
     "private": true,
     "type": "module",
     "exports": {
         "./*": "./*"
     },
     "dependencies": {
-        "@let-value/translate": "1.1.5-beta.2",
-        "@let-value/translate-extract": "1.1.5-beta.2",
-        "@let-value/translate-react": "1.1.5-beta.2",
+        "@let-value/translate": "1.1.5-beta.3",
+        "@let-value/translate-extract": "1.1.5-beta.3",
+        "@let-value/translate-react": "1.1.5-beta.3",
         "gettext-parser": "8.0.0",
         "react": "19.1.1",
         "react-dom": "19.1.1"

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,15 +1,15 @@
 {
     "name": "@let-value/translate-e2e",
-    "version": "1.1.5-beta.1",
+    "version": "1.1.5-beta.2",
     "private": true,
     "type": "module",
     "exports": {
         "./*": "./*"
     },
     "dependencies": {
-        "@let-value/translate": "1.1.5-beta.1",
-        "@let-value/translate-extract": "1.1.5-beta.1",
-        "@let-value/translate-react": "1.1.5-beta.1",
+        "@let-value/translate": "1.1.5-beta.2",
+        "@let-value/translate-extract": "1.1.5-beta.2",
+        "@let-value/translate-react": "1.1.5-beta.2",
         "gettext-parser": "8.0.0",
         "react": "19.1.1",
         "react-dom": "19.1.1"

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,15 +1,15 @@
 {
     "name": "@let-value/translate-e2e",
-    "version": "1.1.4",
+    "version": "1.1.5-beta.1",
     "private": true,
     "type": "module",
     "exports": {
         "./*": "./*"
     },
     "dependencies": {
-        "@let-value/translate": "1.1.4",
-        "@let-value/translate-extract": "1.1.4",
-        "@let-value/translate-react": "1.1.4",
+        "@let-value/translate": "1.1.5-beta.1",
+        "@let-value/translate-extract": "1.1.5-beta.1",
+        "@let-value/translate-react": "1.1.5-beta.1",
         "gettext-parser": "8.0.0",
         "react": "19.1.1",
         "react-dom": "19.1.1"

--- a/extract-static/package.json
+++ b/extract-static/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@let-value/translate-extract-static",
-    "version": "1.1.5-beta.1",
+    "version": "1.1.5-beta.2",
     "type": "module",
     "main": "./dist/src/index.cjs",
     "module": "./dist/src/index.js",
@@ -29,7 +29,7 @@
         "test": "node --test"
     },
     "devDependencies": {
-        "@let-value/translate-extract": "1.1.5-beta.1",
+        "@let-value/translate-extract": "1.1.5-beta.2",
         "@types/bun": "1.3.8",
         "@types/node": "22.10.2",
         "tsdown": "0.15.2",

--- a/extract-static/package.json
+++ b/extract-static/package.json
@@ -5,6 +5,10 @@
     "main": "./dist/src/index.cjs",
     "module": "./dist/src/index.js",
     "types": "./dist/src/index.d.ts",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/let-value/translate"
+    },
     "bin": {
         "extract": "./dist/bin/cli.js"
     },

--- a/extract-static/package.json
+++ b/extract-static/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@let-value/translate-extract-static",
-    "version": "1.1.4",
+    "version": "1.1.5-beta.1",
     "type": "module",
     "main": "./dist/src/index.cjs",
     "module": "./dist/src/index.js",
@@ -29,7 +29,7 @@
         "test": "node --test"
     },
     "devDependencies": {
-        "@let-value/translate-extract": "1.1.4",
+        "@let-value/translate-extract": "1.1.5-beta.1",
         "@types/bun": "1.3.8",
         "@types/node": "22.10.2",
         "tsdown": "0.15.2",

--- a/extract-static/package.json
+++ b/extract-static/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@let-value/translate-extract-static",
-    "version": "1.1.5-beta.2",
+    "version": "1.1.5-beta.3",
     "type": "module",
     "main": "./dist/src/index.cjs",
     "module": "./dist/src/index.js",
@@ -33,7 +33,7 @@
         "test": "node --test"
     },
     "devDependencies": {
-        "@let-value/translate-extract": "1.1.5-beta.2",
+        "@let-value/translate-extract": "1.1.5-beta.3",
         "@types/bun": "1.3.8",
         "@types/node": "22.10.2",
         "tsdown": "0.15.2",

--- a/extract/package.json
+++ b/extract/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@let-value/translate-extract",
-    "version": "1.1.4",
+    "version": "1.1.5-beta.1",
     "type": "module",
     "main": "dist/index.cjs",
     "module": "dist/index.js",
@@ -34,7 +34,7 @@
         "dist"
     ],
     "dependencies": {
-        "@let-value/translate": "1.1.4",
+        "@let-value/translate": "1.1.5-beta.1",
         "chalk": "5.3.0",
         "cosmiconfig": "9.0.0",
         "fast-glob": "3.3.2",

--- a/extract/package.json
+++ b/extract/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@let-value/translate-extract",
-    "version": "1.1.5-beta.2",
+    "version": "1.1.5-beta.3",
     "type": "module",
     "main": "dist/index.cjs",
     "module": "dist/index.js",
@@ -38,7 +38,7 @@
         "dist"
     ],
     "dependencies": {
-        "@let-value/translate": "1.1.5-beta.2",
+        "@let-value/translate": "1.1.5-beta.3",
         "chalk": "5.3.0",
         "cosmiconfig": "9.0.0",
         "fast-glob": "3.3.2",

--- a/extract/package.json
+++ b/extract/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@let-value/translate-extract",
-    "version": "1.1.5-beta.1",
+    "version": "1.1.5-beta.2",
     "type": "module",
     "main": "dist/index.cjs",
     "module": "dist/index.js",
@@ -34,7 +34,7 @@
         "dist"
     ],
     "dependencies": {
-        "@let-value/translate": "1.1.5-beta.1",
+        "@let-value/translate": "1.1.5-beta.2",
         "chalk": "5.3.0",
         "cosmiconfig": "9.0.0",
         "fast-glob": "3.3.2",

--- a/extract/package.json
+++ b/extract/package.json
@@ -5,6 +5,10 @@
     "main": "dist/index.cjs",
     "module": "dist/index.js",
     "types": "dist/index.d.ts",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/let-value/translate"
+    },
     "bin": {
         "extract": "dist/bin/cli.js"
     },

--- a/loader/package.json
+++ b/loader/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@let-value/translate-loader",
-    "version": "1.1.4",
+    "version": "1.1.5-beta.1",
     "type": "module",
     "main": "dist/index.cjs",
     "module": "dist/index.js",

--- a/loader/package.json
+++ b/loader/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@let-value/translate-loader",
-    "version": "1.1.5-beta.1",
+    "version": "1.1.5-beta.2",
     "type": "module",
     "main": "dist/index.cjs",
     "module": "dist/index.js",

--- a/loader/package.json
+++ b/loader/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@let-value/translate-loader",
-    "version": "1.1.5-beta.2",
+    "version": "1.1.5-beta.3",
     "type": "module",
     "main": "dist/index.cjs",
     "module": "dist/index.js",

--- a/loader/package.json
+++ b/loader/package.json
@@ -5,6 +5,10 @@
     "main": "dist/index.cjs",
     "module": "dist/index.js",
     "types": "dist/index.d.ts",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/let-value/translate"
+    },
     "exports": {
         ".": {
             "types": "./dist/index.d.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "translate",
-    "version": "1.1.4",
+    "version": "1.1.5-beta.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "translate",
-            "version": "1.1.4",
+            "version": "1.1.5-beta.1",
             "workspaces": [
                 "loader",
                 "translate",
@@ -26,11 +26,11 @@
         },
         "e2e": {
             "name": "@let-value/translate-e2e",
-            "version": "1.1.4",
+            "version": "1.1.5-beta.1",
             "dependencies": {
-                "@let-value/translate": "1.1.4",
-                "@let-value/translate-extract": "1.1.4",
-                "@let-value/translate-react": "1.1.4",
+                "@let-value/translate": "1.1.5-beta.1",
+                "@let-value/translate-extract": "1.1.5-beta.1",
+                "@let-value/translate-react": "1.1.5-beta.1",
                 "gettext-parser": "8.0.0",
                 "react": "19.1.1",
                 "react-dom": "19.1.1"
@@ -38,10 +38,10 @@
         },
         "extract": {
             "name": "@let-value/translate-extract",
-            "version": "1.1.4",
+            "version": "1.1.5-beta.1",
             "dependencies": {
                 "@keqingmoe/tree-sitter": "0.26.2",
-                "@let-value/translate": "1.1.4",
+                "@let-value/translate": "1.1.5-beta.1",
                 "chalk": "5.3.0",
                 "cosmiconfig": "9.0.0",
                 "fast-glob": "3.3.2",
@@ -64,7 +64,7 @@
         },
         "extract-static": {
             "name": "@let-value/translate-extract-static",
-            "version": "1.1.4",
+            "version": "1.1.5-beta.1",
             "hasInstallScript": true,
             "dependencies": {
                 "detect-libc": "2.1.2"
@@ -73,7 +73,7 @@
                 "extract": "dist/bin/cli.js"
             },
             "devDependencies": {
-                "@let-value/translate-extract": "1.1.4",
+                "@let-value/translate-extract": "1.1.5-beta.1",
                 "@types/bun": "1.3.8",
                 "@types/node": "22.10.2",
                 "tsdown": "0.15.2",
@@ -138,7 +138,7 @@
         },
         "loader": {
             "name": "@let-value/translate-loader",
-            "version": "1.1.4",
+            "version": "1.1.5-beta.1",
             "dependencies": {
                 "gettext-parser": "8.0.0",
                 "unplugin": "2.3.10"
@@ -2660,12 +2660,12 @@
         },
         "react": {
             "name": "@let-value/translate-react",
-            "version": "1.1.4",
+            "version": "1.1.5-beta.1",
             "dependencies": {
-                "@let-value/translate": "1.1.4"
+                "@let-value/translate": "1.1.5-beta.1"
             },
             "devDependencies": {
-                "@let-value/translate-e2e": "1.1.4",
+                "@let-value/translate-e2e": "1.1.5-beta.1",
                 "@types/gettext-parser": "8.0.0",
                 "@types/react": "19.1.13",
                 "@types/react-dom": "19.1.9",
@@ -2680,7 +2680,7 @@
         },
         "translate": {
             "name": "@let-value/translate",
-            "version": "1.1.4",
+            "version": "1.1.5-beta.1",
             "dependencies": {
                 "plural-forms": "0.5.5"
             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "translate",
-    "version": "1.1.5-beta.2",
+    "version": "1.1.5-beta.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "translate",
-            "version": "1.1.5-beta.2",
+            "version": "1.1.5-beta.3",
             "workspaces": [
                 "loader",
                 "translate",
@@ -26,11 +26,11 @@
         },
         "e2e": {
             "name": "@let-value/translate-e2e",
-            "version": "1.1.5-beta.2",
+            "version": "1.1.5-beta.3",
             "dependencies": {
-                "@let-value/translate": "1.1.5-beta.2",
-                "@let-value/translate-extract": "1.1.5-beta.2",
-                "@let-value/translate-react": "1.1.5-beta.2",
+                "@let-value/translate": "1.1.5-beta.3",
+                "@let-value/translate-extract": "1.1.5-beta.3",
+                "@let-value/translate-react": "1.1.5-beta.3",
                 "gettext-parser": "8.0.0",
                 "react": "19.1.1",
                 "react-dom": "19.1.1"
@@ -38,10 +38,10 @@
         },
         "extract": {
             "name": "@let-value/translate-extract",
-            "version": "1.1.5-beta.2",
+            "version": "1.1.5-beta.3",
             "dependencies": {
                 "@keqingmoe/tree-sitter": "0.26.2",
-                "@let-value/translate": "1.1.5-beta.2",
+                "@let-value/translate": "1.1.5-beta.3",
                 "chalk": "5.3.0",
                 "cosmiconfig": "9.0.0",
                 "fast-glob": "3.3.2",
@@ -64,7 +64,7 @@
         },
         "extract-static": {
             "name": "@let-value/translate-extract-static",
-            "version": "1.1.5-beta.2",
+            "version": "1.1.5-beta.3",
             "hasInstallScript": true,
             "dependencies": {
                 "detect-libc": "2.1.2"
@@ -73,7 +73,7 @@
                 "extract": "dist/bin/cli.js"
             },
             "devDependencies": {
-                "@let-value/translate-extract": "1.1.5-beta.2",
+                "@let-value/translate-extract": "1.1.5-beta.3",
                 "@types/bun": "1.3.8",
                 "@types/node": "22.10.2",
                 "tsdown": "0.15.2",
@@ -138,7 +138,7 @@
         },
         "loader": {
             "name": "@let-value/translate-loader",
-            "version": "1.1.5-beta.2",
+            "version": "1.1.5-beta.3",
             "dependencies": {
                 "gettext-parser": "8.0.0",
                 "unplugin": "2.3.10"
@@ -2660,12 +2660,12 @@
         },
         "react": {
             "name": "@let-value/translate-react",
-            "version": "1.1.5-beta.2",
+            "version": "1.1.5-beta.3",
             "dependencies": {
-                "@let-value/translate": "1.1.5-beta.2"
+                "@let-value/translate": "1.1.5-beta.3"
             },
             "devDependencies": {
-                "@let-value/translate-e2e": "1.1.5-beta.2",
+                "@let-value/translate-e2e": "1.1.5-beta.3",
                 "@types/gettext-parser": "8.0.0",
                 "@types/react": "19.1.13",
                 "@types/react-dom": "19.1.9",
@@ -2680,7 +2680,7 @@
         },
         "translate": {
             "name": "@let-value/translate",
-            "version": "1.1.5-beta.2",
+            "version": "1.1.5-beta.3",
             "dependencies": {
                 "plural-forms": "0.5.5"
             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "translate",
-    "version": "1.1.5-beta.1",
+    "version": "1.1.5-beta.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "translate",
-            "version": "1.1.5-beta.1",
+            "version": "1.1.5-beta.2",
             "workspaces": [
                 "loader",
                 "translate",
@@ -26,11 +26,11 @@
         },
         "e2e": {
             "name": "@let-value/translate-e2e",
-            "version": "1.1.5-beta.1",
+            "version": "1.1.5-beta.2",
             "dependencies": {
-                "@let-value/translate": "1.1.5-beta.1",
-                "@let-value/translate-extract": "1.1.5-beta.1",
-                "@let-value/translate-react": "1.1.5-beta.1",
+                "@let-value/translate": "1.1.5-beta.2",
+                "@let-value/translate-extract": "1.1.5-beta.2",
+                "@let-value/translate-react": "1.1.5-beta.2",
                 "gettext-parser": "8.0.0",
                 "react": "19.1.1",
                 "react-dom": "19.1.1"
@@ -38,10 +38,10 @@
         },
         "extract": {
             "name": "@let-value/translate-extract",
-            "version": "1.1.5-beta.1",
+            "version": "1.1.5-beta.2",
             "dependencies": {
                 "@keqingmoe/tree-sitter": "0.26.2",
-                "@let-value/translate": "1.1.5-beta.1",
+                "@let-value/translate": "1.1.5-beta.2",
                 "chalk": "5.3.0",
                 "cosmiconfig": "9.0.0",
                 "fast-glob": "3.3.2",
@@ -64,7 +64,7 @@
         },
         "extract-static": {
             "name": "@let-value/translate-extract-static",
-            "version": "1.1.5-beta.1",
+            "version": "1.1.5-beta.2",
             "hasInstallScript": true,
             "dependencies": {
                 "detect-libc": "2.1.2"
@@ -73,7 +73,7 @@
                 "extract": "dist/bin/cli.js"
             },
             "devDependencies": {
-                "@let-value/translate-extract": "1.1.5-beta.1",
+                "@let-value/translate-extract": "1.1.5-beta.2",
                 "@types/bun": "1.3.8",
                 "@types/node": "22.10.2",
                 "tsdown": "0.15.2",
@@ -138,7 +138,7 @@
         },
         "loader": {
             "name": "@let-value/translate-loader",
-            "version": "1.1.5-beta.1",
+            "version": "1.1.5-beta.2",
             "dependencies": {
                 "gettext-parser": "8.0.0",
                 "unplugin": "2.3.10"
@@ -2660,12 +2660,12 @@
         },
         "react": {
             "name": "@let-value/translate-react",
-            "version": "1.1.5-beta.1",
+            "version": "1.1.5-beta.2",
             "dependencies": {
-                "@let-value/translate": "1.1.5-beta.1"
+                "@let-value/translate": "1.1.5-beta.2"
             },
             "devDependencies": {
-                "@let-value/translate-e2e": "1.1.5-beta.1",
+                "@let-value/translate-e2e": "1.1.5-beta.2",
                 "@types/gettext-parser": "8.0.0",
                 "@types/react": "19.1.13",
                 "@types/react-dom": "19.1.9",
@@ -2680,7 +2680,7 @@
         },
         "translate": {
             "name": "@let-value/translate",
-            "version": "1.1.5-beta.1",
+            "version": "1.1.5-beta.2",
             "dependencies": {
                 "plural-forms": "0.5.5"
             },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "translate",
-    "version": "1.1.4",
+    "version": "1.1.5-beta.1",
     "type": "module",
     "private": true,
     "workspaces": [

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
     "version": "1.1.5-beta.2",
     "type": "module",
     "private": true,
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/let-value/translate"
+    },
     "workspaces": [
         "loader",
         "translate",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "translate",
-    "version": "1.1.5-beta.2",
+    "version": "1.1.5-beta.3",
     "type": "module",
     "private": true,
     "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "translate",
-    "version": "1.1.5-beta.1",
+    "version": "1.1.5-beta.2",
     "type": "module",
     "private": true,
     "workspaces": [

--- a/react/package.json
+++ b/react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@let-value/translate-react",
-    "version": "1.1.5-beta.1",
+    "version": "1.1.5-beta.2",
     "type": "module",
     "main": "dist/index.cjs",
     "module": "dist/index.js",
@@ -24,10 +24,10 @@
         "test": "node --test"
     },
     "dependencies": {
-        "@let-value/translate": "1.1.5-beta.1"
+        "@let-value/translate": "1.1.5-beta.2"
     },
     "devDependencies": {
-        "@let-value/translate-e2e": "1.1.5-beta.1",
+        "@let-value/translate-e2e": "1.1.5-beta.2",
         "@types/gettext-parser": "8.0.0",
         "@types/react": "19.1.13",
         "@types/react-dom": "19.1.9",

--- a/react/package.json
+++ b/react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@let-value/translate-react",
-    "version": "1.1.4",
+    "version": "1.1.5-beta.1",
     "type": "module",
     "main": "dist/index.cjs",
     "module": "dist/index.js",
@@ -24,10 +24,10 @@
         "test": "node --test"
     },
     "dependencies": {
-        "@let-value/translate": "1.1.4"
+        "@let-value/translate": "1.1.5-beta.1"
     },
     "devDependencies": {
-        "@let-value/translate-e2e": "1.1.4",
+        "@let-value/translate-e2e": "1.1.5-beta.1",
         "@types/gettext-parser": "8.0.0",
         "@types/react": "19.1.13",
         "@types/react-dom": "19.1.9",

--- a/react/package.json
+++ b/react/package.json
@@ -5,6 +5,10 @@
     "main": "dist/index.cjs",
     "module": "dist/index.js",
     "types": "dist/index.d.ts",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/let-value/translate"
+    },
     "exports": {
         ".": {
             "types": "./dist/index.d.ts",

--- a/react/package.json
+++ b/react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@let-value/translate-react",
-    "version": "1.1.5-beta.2",
+    "version": "1.1.5-beta.3",
     "type": "module",
     "main": "dist/index.cjs",
     "module": "dist/index.js",
@@ -28,10 +28,10 @@
         "test": "node --test"
     },
     "dependencies": {
-        "@let-value/translate": "1.1.5-beta.2"
+        "@let-value/translate": "1.1.5-beta.3"
     },
     "devDependencies": {
-        "@let-value/translate-e2e": "1.1.5-beta.2",
+        "@let-value/translate-e2e": "1.1.5-beta.3",
         "@types/gettext-parser": "8.0.0",
         "@types/react": "19.1.13",
         "@types/react-dom": "19.1.9",

--- a/translate/package.json
+++ b/translate/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@let-value/translate",
-    "version": "1.1.5-beta.2",
+    "version": "1.1.5-beta.3",
     "type": "module",
     "main": "dist/index.cjs",
     "module": "dist/index.js",

--- a/translate/package.json
+++ b/translate/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@let-value/translate",
-    "version": "1.1.4",
+    "version": "1.1.5-beta.1",
     "type": "module",
     "main": "dist/index.cjs",
     "module": "dist/index.js",

--- a/translate/package.json
+++ b/translate/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@let-value/translate",
-    "version": "1.1.5-beta.1",
+    "version": "1.1.5-beta.2",
     "type": "module",
     "main": "dist/index.cjs",
     "module": "dist/index.js",

--- a/translate/package.json
+++ b/translate/package.json
@@ -5,6 +5,10 @@
     "main": "dist/index.cjs",
     "module": "dist/index.js",
     "types": "dist/index.d.ts",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/let-value/translate"
+    },
     "exports": {
         ".": {
             "types": "./dist/index.d.ts",


### PR DESCRIPTION
## What changed

- Split the release publish matrix into separate GitHub Packages and npm registry jobs.
- Updated the npm publish job to use GitHub Actions OIDC trusted publishing with `id-token: write`.
- Removed `NPM_TOKEN` usage from npm registry publishing.
- Disabled package-manager caching in release setup-node steps and updated release workflow actions to `checkout@v6` / `setup-node@v6`.

## Why

npm trusted publishing uses short-lived OIDC credentials instead of a long-lived npm token. The previous workflow still expected `NPM_TOKEN`, which caused npm publish auth failures after trusted publishing was configured.

## Validation

- Ran `git diff --check`; only the expected Windows line-ending warning was reported.
- Verified GitHub CLI authentication and repository default branch before pushing.

The actual npm publish path requires GitHub Actions OIDC context, so it was not run locally.