### PR TITLE
[codex] Fix extractor dependency excludes

### DIFF
--- a/extract/src/configuration.ts
+++ b/extract/src/configuration.ts
@@ -1,13 +1,15 @@
 import { basename, dirname, extname, join } from "node:path";
 import type { PluralFormsLocale } from "@let-value/translate";
+import { type DefaultExclude, defaultExclude, defaultExcludes } from "./exclude.ts";
 import type { LogLevel } from "./logger.ts";
 
-import type { UniversalPlugin } from "./plugin.ts";
+import type { ResolveArgs, UniversalPlugin } from "./plugin.ts";
 import { cleanup, core, po } from "./static.ts";
 
 export type DestinationFn = (args: { locale: string; entrypoint: string; path: string }) => string;
-export type ExcludeFn = (args: { entrypoint: string; path: string }) => boolean;
+export type ExcludeFn = (args: ResolveArgs) => boolean;
 export type Exclude = RegExp | ExcludeFn;
+export type ExcludeConfig = RegExp | Exclude[] | ((defaultExclude: DefaultExclude) => Exclude[]);
 
 const defaultPlugins = { core, po, cleanup };
 type DefaultPlugins = typeof defaultPlugins;
@@ -24,7 +26,7 @@ export interface EntrypointConfig {
     destination?: DestinationFn;
     obsolete?: ObsoleteStrategy;
     walk?: boolean;
-    exclude?: Exclude | Exclude[];
+    exclude?: ExcludeConfig;
 }
 
 export interface UserConfig {
@@ -79,7 +81,7 @@ export interface UserConfig {
      * @default [/node_modules/, /dist/, /build/]
      * @see Can be overridden per entrypoint via `exclude` in {@link EntrypointConfig}.
      */
-    exclude?: Exclude | Exclude[];
+    exclude?: ExcludeConfig;
     /**
      * Log level for the extraction process
      * @default "info"
@@ -106,15 +108,17 @@ export interface ResolvedConfig {
 const defaultDestination: DestinationFn = ({ entrypoint, locale }) =>
     join(dirname(entrypoint), "translations", `${basename(entrypoint, extname(entrypoint))}.${locale}.po`);
 
-const defaultExclude: Exclude[] = [
-    /(?:^|[\\/])node_modules(?:[\\/]|$)/,
-    /(?:^|[\\/])dist(?:[\\/]|$)/,
-    /(?:^|[\\/])build(?:[\\/]|$)/,
-];
-
-function normalizeExclude(exclude?: Exclude | Exclude[]): Exclude[] {
+function normalizeExclude(exclude?: RegExp | Exclude[]): Exclude[] {
     if (!exclude) return [];
     return Array.isArray(exclude) ? exclude : [exclude];
+}
+
+function resolveExcludes(exclude?: ExcludeConfig): Exclude[] {
+    if (typeof exclude === "function") {
+        return exclude(defaultExclude);
+    }
+
+    return [...defaultExcludes, ...normalizeExclude(exclude)];
 }
 
 function resolveEntrypoint(ep: string | EntrypointConfig): ResolvedEntrypoint {
@@ -122,7 +126,13 @@ function resolveEntrypoint(ep: string | EntrypointConfig): ResolvedEntrypoint {
         return { entrypoint: ep };
     }
     const { entrypoint, destination, obsolete, walk, exclude } = ep;
-    return { entrypoint, destination, obsolete, walk, exclude: exclude ? normalizeExclude(exclude) : undefined };
+    return {
+        entrypoint,
+        destination,
+        obsolete,
+        walk,
+        exclude: exclude ? resolveExcludes(exclude) : undefined,
+    };
 }
 
 function resolvePlugins(user?: UserConfig["plugins"]): UniversalPlugin[] {
@@ -156,6 +166,6 @@ export function defineConfig(config: UserConfig): ResolvedConfig {
         obsolete: config.obsolete ?? "mark",
         walk: config.walk ?? true,
         logLevel: config.logLevel ?? "info",
-        exclude: config.exclude ? normalizeExclude(config.exclude) : defaultExclude,
+        exclude: resolveExcludes(config.exclude),
     };
 }

--- a/extract/src/exclude.ts
+++ b/extract/src/exclude.ts
@@ -1,0 +1,27 @@
+import type { Exclude } from "./configuration.ts";
+import type { ResolveArgs } from "./plugin.ts";
+
+function normalizedPath(path: string) {
+    return path.replace(/\\/g, "/");
+}
+
+function isInsideDirectory(path: string, directory: string) {
+    return normalizedPath(path)
+        .split("/")
+        .some((part) => part === directory);
+}
+
+export const defaultExclude = {
+    modules: ({ path }: ResolveArgs) => isInsideDirectory(path, "node_modules"),
+    dist: ({ path }: ResolveArgs) => isInsideDirectory(path, "dist"),
+    build: ({ path }: ResolveArgs) => isInsideDirectory(path, "build"),
+    types: ({ import: imp }: ResolveArgs) => imp?.typeOnly ?? false,
+} as const;
+
+export type DefaultExclude = typeof defaultExclude;
+
+export const defaultExcludes: Exclude[] = Object.values(defaultExclude);
+
+export function isExcluded(args: ResolveArgs, exclude: Exclude[]) {
+    return exclude.some((ex) => (typeof ex === "function" ? ex(args) : ex.test(args.path)));
+}

--- a/extract/src/plugin.ts
+++ b/extract/src/plugin.ts
@@ -11,10 +11,17 @@ export interface Context {
     logger?: Logger;
 }
 
+export interface ImportReference {
+    spec: string;
+    kind: "static" | "dynamic";
+    typeOnly: boolean;
+}
+
 export interface ResolveArgs<TInput = unknown> {
     entrypoint: string;
     path: string;
     namespace: string;
+    import?: ImportReference;
     data?: TInput;
 }
 
@@ -22,6 +29,7 @@ export interface ResolveResult<TInput = unknown> {
     entrypoint: string;
     path: string;
     namespace: string;
+    import?: ImportReference;
     data?: TInput;
 }
 

--- a/extract/src/plugins/core/core.ts
+++ b/extract/src/plugins/core/core.ts
@@ -1,6 +1,7 @@
 import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 
+import { isExcluded } from "../../exclude.ts";
 import type { Plugin } from "../../plugin.ts";
 import { parseSource } from "./parse.ts";
 import type { Translation } from "./queries/types.ts";
@@ -15,11 +16,13 @@ export function core(): Plugin<string, Translation[]> {
         setup(build) {
             build.context.logger?.debug("core plugin initialized");
 
-            build.onResolve({ filter, namespace }, ({ entrypoint, path }) => {
+            build.onResolve({ filter, namespace }, ({ entrypoint, path, import: imp, data }) => {
                 return {
                     entrypoint,
                     namespace,
                     path: resolve(path),
+                    import: imp,
+                    data,
                 };
             });
 
@@ -44,15 +47,22 @@ export function core(): Plugin<string, Translation[]> {
                 const { translations, imports, warnings } = result;
 
                 if (build.context.config.walk) {
-                    const { resolved: paths, unresolved } = resolveImportResults(path, imports);
-                    for (const path of paths) {
-                        if (build.context.paths.has(path)) {
+                    const { resolved, unresolved } = resolveImportResults(path, imports);
+                    for (const result of resolved) {
+                        if (build.context.paths.has(result.path)) {
                             continue;
                         }
 
-                        build.resolve({ entrypoint, path, namespace });
+                        build.resolve({ entrypoint, path: result.path, namespace, import: result.import });
                     }
                     for (const { spec, error } of unresolved) {
+                        const imp = imports.find((imp) => imp.spec === spec);
+                        if (
+                            imp &&
+                            isExcluded({ entrypoint, path: spec, namespace, import: imp }, build.context.config.exclude)
+                        ) {
+                            continue;
+                        }
                         build.context.logger?.warn(
                             `Unable to resolve import "${spec}" from ${path}${error ? `: ${error}` : ""}`,
                         );

--- a/extract/src/plugins/core/parse.ts
+++ b/extract/src/plugins/core/parse.ts
@@ -5,6 +5,7 @@ import Parser from "@keqingmoe/tree-sitter";
 import JavaScript from "tree-sitter-javascript";
 import TS from "tree-sitter-typescript";
 
+import type { ImportReference } from "../../plugin.ts";
 import { getReference } from "./queries/comment.ts";
 import { entrypointQuery } from "./queries/entrypoint.ts";
 import { importQuery } from "./queries/import.ts";
@@ -13,7 +14,7 @@ import type { Context, Translation, Warning } from "./queries/types.ts";
 
 export interface ParseResult {
     translations: Translation[];
-    imports: string[];
+    imports: ImportReference[];
     warnings: Warning[];
     entrypoint: boolean;
 }
@@ -88,7 +89,7 @@ export function parseSource(source: string, path: string): ParseResult {
 
     const translations: Translation[] = [];
     const warnings: Warning[] = [];
-    const imports: string[] = [];
+    const imports: ImportReference[] = [];
 
     const seen = new Set<number>();
 

--- a/extract/src/plugins/core/queries/import.ts
+++ b/extract/src/plugins/core/queries/import.ts
@@ -1,5 +1,34 @@
 import type Parser from "@keqingmoe/tree-sitter";
+import type { ImportReference } from "../../../plugin.ts";
 import type { ImportQuerySpec } from "./types.ts";
+
+function findImportParent(node: Parser.SyntaxNode): Parser.SyntaxNode | undefined {
+    let current: Parser.SyntaxNode | null = node;
+    while (current) {
+        if (
+            current.type === "import_statement" ||
+            current.type === "export_statement" ||
+            current.type === "call_expression"
+        ) {
+            return current;
+        }
+        current = current.parent;
+    }
+    return undefined;
+}
+
+function isTypeOnly(parent: Parser.SyntaxNode | undefined) {
+    if (!parent) {
+        return false;
+    }
+
+    const text = parent.text.trimStart();
+    return (
+        /^import\s+type\b/.test(text) ||
+        /^export\s+type\b/.test(text) ||
+        /^export\s*{\s*type\b[^}]*}\s*from\b/.test(text)
+    );
+}
 
 export const importQuery: ImportQuerySpec = {
     pattern: `
@@ -20,12 +49,21 @@ export const importQuery: ImportQuerySpec = {
         (#eq? @obj "require")
         (#eq? @method "resolve"))
       (call_expression
-        function: (import)
+        function: (import) @dynamic
         arguments: (arguments (string (string_fragment) @import)))
     ]
   `,
-    extract(match: Parser.QueryMatch): string | undefined {
+    extract(match: Parser.QueryMatch): ImportReference | undefined {
         const node = match.captures.find((c) => c.name === "import")?.node;
-        return node?.text;
+        if (!node) {
+            return undefined;
+        }
+
+        const parent = findImportParent(node);
+        return {
+            spec: node.text,
+            kind: match.captures.some((c) => c.name === "dynamic") ? "dynamic" : "static",
+            typeOnly: isTypeOnly(parent),
+        };
     },
 };

--- a/extract/src/plugins/core/queries/tests/import.test.ts
+++ b/extract/src/plugins/core/queries/tests/import.test.ts
@@ -12,18 +12,43 @@ suite("should extract imports", () =>
     paths.forEach((path) => {
         test(path, () => {
             const matches = getMatches(fixture, path, importQuery);
-            assert.deepEqual(matches, [
-                "default-export",
-                "named-export",
-                "namespace-export",
-                "side-effect",
-                "export-all",
-                "export-from",
-                "cjs-module",
-                "resolved-module",
-                "dynamic-import",
-                "async-import",
-            ]);
+            assert.deepEqual(
+                matches.map((match) => match.spec),
+                [
+                    "default-export",
+                    "named-export",
+                    "namespace-export",
+                    "side-effect",
+                    "export-all",
+                    "export-from",
+                    "cjs-module",
+                    "resolved-module",
+                    "dynamic-import",
+                    "async-import",
+                ],
+            );
         });
     }),
 );
+
+test("marks type-only and dynamic imports", () => {
+    const matches = getMatches(
+        `
+import type { Props } from "./props";
+export type { Model } from "./model";
+export { type Shape } from "./shape";
+import { type Label, value } from "./mixed";
+import("./lazy");
+`,
+        "test.ts",
+        importQuery,
+    );
+
+    assert.deepEqual(matches, [
+        { spec: "./props", kind: "static", typeOnly: true },
+        { spec: "./model", kind: "static", typeOnly: true },
+        { spec: "./shape", kind: "static", typeOnly: true },
+        { spec: "./mixed", kind: "static", typeOnly: false },
+        { spec: "./lazy", kind: "dynamic", typeOnly: false },
+    ]);
+});

--- a/extract/src/plugins/core/queries/types.ts
+++ b/extract/src/plugins/core/queries/types.ts
@@ -1,4 +1,5 @@
 import type Parser from "@keqingmoe/tree-sitter";
+import type { ImportReference } from "../../../plugin.ts";
 
 export interface Comments {
     translator?: string;
@@ -44,5 +45,5 @@ export interface QuerySpec {
 
 export interface ImportQuerySpec {
     pattern: string;
-    extract(match: Parser.QueryMatch): string | undefined;
+    extract(match: Parser.QueryMatch): ImportReference | undefined;
 }

--- a/extract/src/plugins/core/resolve.ts
+++ b/extract/src/plugins/core/resolve.ts
@@ -1,6 +1,8 @@
 import fs from "node:fs";
+import { builtinModules } from "node:module";
 import path from "node:path";
 import { ResolverFactory } from "oxc-resolver";
+import type { ImportReference } from "../../plugin.ts";
 
 export interface UnresolvedImport {
     spec: string;
@@ -8,7 +10,7 @@ export interface UnresolvedImport {
 }
 
 export interface ResolveImportsResult {
-    resolved: string[];
+    resolved: Array<{ path: string; import: ImportReference }>;
     unresolved: UnresolvedImport[];
 }
 
@@ -28,6 +30,17 @@ function findTsconfig(dir: string): string | undefined {
 }
 
 const resolverCache = new Map<string, ResolverFactory>();
+const builtins = new Set([...builtinModules, ...builtinModules.map((name) => `node:${name}`)]);
+
+function isBuiltin(spec: string) {
+    if (builtins.has(spec)) {
+        return true;
+    }
+
+    const withoutNodePrefix = spec.startsWith("node:") ? spec.slice("node:".length) : spec;
+    const [base, subpath] = withoutNodePrefix.split("/", 2);
+    return subpath !== undefined && builtins.has(base);
+}
 
 function getResolver(dir: string) {
     const tsconfig = findTsconfig(dir);
@@ -51,6 +64,10 @@ function resolveFromDir(dir: string, spec: string): string | undefined {
 }
 
 export function resolveImport(file: string, spec: string): string | undefined {
+    if (isBuiltin(spec)) {
+        return undefined;
+    }
+
     const dir = path.dirname(path.resolve(file));
     try {
         return resolveFromDir(dir, spec);
@@ -59,21 +76,34 @@ export function resolveImport(file: string, spec: string): string | undefined {
     }
 }
 
-export function resolveImports(file: string, imports: string[]): string[] {
-    return resolveImportResults(file, imports).resolved;
+export function resolveImports(file: string, imports: Array<string | ImportReference>): string[] {
+    return resolveImportResults(file, imports).resolved.map((result) => result.path);
 }
 
-export function resolveImportResults(file: string, imports: string[]): ResolveImportsResult {
+function normalizeImportReference(imp: string | ImportReference): ImportReference {
+    if (typeof imp === "string") {
+        return { spec: imp, kind: "static", typeOnly: false };
+    }
+    return imp;
+}
+
+export function resolveImportResults(file: string, imports: Array<string | ImportReference>): ResolveImportsResult {
     const dir = path.dirname(path.resolve(file));
     const resolver = getResolver(dir);
-    const resolved: string[] = [];
+    const resolved: Array<{ path: string; import: ImportReference }> = [];
     const unresolved: UnresolvedImport[] = [];
 
-    for (const spec of imports) {
+    for (const imp of imports) {
+        const ref = normalizeImportReference(imp);
+        const { spec } = ref;
+        if (isBuiltin(spec)) {
+            continue;
+        }
+
         try {
             const res = resolver.sync(dir, spec) as { error?: string; path?: string };
             if (res.path) {
-                resolved.push(res.path);
+                resolved.push({ path: res.path, import: { ...ref, spec: res.path } });
             } else {
                 unresolved.push({ spec, error: res.error });
             }

--- a/extract/src/plugins/core/tests/resolve.test.ts
+++ b/extract/src/plugins/core/tests/resolve.test.ts
@@ -55,6 +55,11 @@ suite("resolveImports - app", () => {
         assert.equal(result.unresolved[0]?.spec, "#/missing");
         assert.match(result.unresolved[0]?.error ?? "", /Can't resolve|Cannot find module|not found/i);
     });
+
+    test("ignores Node builtins", () => {
+        assert.equal(resolveImport(appEntryPath, "node:path/posix"), undefined);
+        assert.deepEqual(resolveImportResults(appEntryPath, ["node:path", "fs"]).unresolved, []);
+    });
 });
 
 const libCases: Record<string, string> = {

--- a/extract/src/run.ts
+++ b/extract/src/run.ts
@@ -2,6 +2,7 @@ import { resolve as resolvePath } from "node:path";
 import glob from "fast-glob";
 import type { ResolvedConfig, ResolvedEntrypoint } from "./configuration.ts";
 import { Defer } from "./defer.ts";
+import { isExcluded } from "./exclude.ts";
 import type { Logger } from "./logger.ts";
 import type {
     Build,
@@ -100,7 +101,7 @@ export async function run(
         const key = `${entrypoint}:${namespace}:${path}`;
 
         const visited = resolved.has(key);
-        const skipped = context.config.exclude.some((ex) => (typeof ex === "function" ? ex(args) : ex.test(args.path)));
+        const skipped = isExcluded(args, context.config.exclude);
         logger?.debug({ entrypoint, path, namespace, skipped, visited }, "resolve");
 
         if (namespace === "source" && visited) {

--- a/extract/src/tests/configuration.test.ts
+++ b/extract/src/tests/configuration.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { join } from "node:path";
 import { test } from "node:test";
 import { type DestinationFn, defineConfig } from "../configuration.ts";
+import { isExcluded } from "../exclude.ts";
 import type { Plugin } from "../plugin.ts";
 import type { StaticPlugin } from "../static.ts";
 
@@ -79,12 +80,29 @@ test("configures walk option", () => {
 
 test("provides default excludes", () => {
     const cfg = defineConfig({ entrypoints: "src/index.ts" });
-    assert(cfg.exclude.some((e) => e instanceof RegExp && e.test("node_modules/somefile")));
-    assert(cfg.exclude.some((e) => e instanceof RegExp && e.test("dist/somefile")));
-    assert(cfg.exclude.some((e) => e instanceof RegExp && e.test("build/somefile")));
+    assert(isExcluded({ entrypoint: "src/index.ts", path: "node_modules/somefile", namespace: "source" }, cfg.exclude));
+    assert(
+        isExcluded(
+            { entrypoint: "src/index.ts", path: String.raw`D:\repo\node_modules\pkg\index.js`, namespace: "source" },
+            cfg.exclude,
+        ),
+    );
+    assert(isExcluded({ entrypoint: "src/index.ts", path: "dist/somefile", namespace: "source" }, cfg.exclude));
+    assert(isExcluded({ entrypoint: "src/index.ts", path: "build/somefile", namespace: "source" }, cfg.exclude));
+    assert(
+        isExcluded(
+            {
+                entrypoint: "src/index.ts",
+                path: join(process.cwd(), "types.ts"),
+                namespace: "source",
+                import: { spec: join(process.cwd(), "types.ts"), kind: "static", typeOnly: true },
+            },
+            cfg.exclude,
+        ),
+    );
 });
 
-test("supports exclude overrides", () => {
+test("adds custom excludes to defaults", () => {
     const cfg = defineConfig({
         entrypoints: [{ entrypoint: "src/index.ts", exclude: /skip/ }],
         exclude: [/global/, /node_modules/],
@@ -94,8 +112,29 @@ test("supports exclude overrides", () => {
     const epExclude = cfg.entrypoints[0].exclude;
     assert(epExclude);
     assert(epExclude.some((e) => e instanceof RegExp && e.test("skip")));
+    assert(isExcluded({ entrypoint: "src/index.ts", path: "node_modules/foo", namespace: "source" }, epExclude));
     assert(!epExclude.some((e) => e instanceof RegExp && e.test("global")));
-    assert(!epExclude.some((e) => e instanceof RegExp && e.test("node_modules/foo")));
+});
+
+test("allows selecting named default excludes", () => {
+    const cfg = defineConfig({
+        entrypoints: "src/index.ts",
+        exclude: ({ modules, types }) => [modules, types],
+    });
+
+    assert(isExcluded({ entrypoint: "src/index.ts", path: "node_modules/foo", namespace: "source" }, cfg.exclude));
+    assert(!isExcluded({ entrypoint: "src/index.ts", path: "dist/foo", namespace: "source" }, cfg.exclude));
+    assert(
+        isExcluded(
+            {
+                entrypoint: "src/index.ts",
+                path: join(process.cwd(), "types.ts"),
+                namespace: "source",
+                import: { spec: join(process.cwd(), "types.ts"), kind: "static", typeOnly: true },
+            },
+            cfg.exclude,
+        ),
+    );
 });
 
 test("defaults log level to info", () => {

--- a/extract/src/tests/run.test.ts
+++ b/extract/src/tests/run.test.ts
@@ -74,7 +74,7 @@ test("skips resolving paths matching exclude", async () => {
 
     const config = defineConfig({
         entrypoints: entrypoint,
-        exclude: (p) => p.path === extra,
+        exclude: [(p) => p.path === extra],
         plugins: () => [plugin],
     });
     await run(config.entrypoints[0], { config });
@@ -391,4 +391,108 @@ export const b = 2;
 
     assert.equal(menuPo.includes('msgid "menu"'), true);
     assert.equal(menuPo.includes('msgid "page"'), false);
+});
+
+test("does not walk type-only imports by default and allows excluding dynamic router imports", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "translate-extract-"));
+    const authDir = join(directory, "auth", "signIn");
+    const providersDir = join(directory, "auth", "providers");
+    const appDir = join(directory, "app");
+    const userDir = join(appDir, "user");
+    await mkdir(authDir, { recursive: true });
+    await mkdir(providersDir, { recursive: true });
+    await mkdir(userDir, { recursive: true });
+
+    const page = join(authDir, "page.tsx");
+    const button = join(providersDir, "button.tsx");
+    const oauth = join(providersDir, "oauth.tsx");
+    const ioc = join(directory, "ioc.ts");
+    const route = join(appDir, "route.ts");
+    const userRoute = join(userDir, "route.tsx");
+    const userPage = join(userDir, "page.tsx");
+    const followButton = join(userDir, "follow-button.tsx");
+    const serverTypes = join(authDir, "server-types.ts");
+    const dynamicImportSpecs: string[] = [];
+
+    await writeFile(
+        page,
+        `import type { ServerParams } from "./server-types";
+import "../providers/button";
+message("sign-in");
+export type { ServerParams };
+`,
+    );
+    await writeFile(button, `import "./oauth";`);
+    await writeFile(oauth, `import { container } from "../../ioc"; export { container };`);
+    await writeFile(
+        ioc,
+        `export const container = {
+    router: async () => {
+        const { createRouter } = await import("./app/route");
+        return createRouter();
+    },
+};
+`,
+    );
+    await writeFile(route, `import { user } from "./user/route"; export const createRouter = () => user;`);
+    await writeFile(userRoute, `export const user = { lazy: () => import("./page") };`);
+    await writeFile(userPage, `import "./follow-button";`);
+    await writeFile(followButton, `message("Friends", { context: "follow-button" });`);
+    await writeFile(serverTypes, `message("server-only"); export interface ServerParams { id: string }`);
+
+    const config = defineConfig({
+        entrypoints: page,
+        exclude: [
+            (args) => {
+                if (args.import?.kind !== "dynamic") {
+                    return false;
+                }
+                dynamicImportSpecs.push(args.import.spec);
+                return true;
+            },
+        ],
+    });
+    await run(config.entrypoints[0], { config });
+
+    const pagePo = await readFile(join(authDir, "translations", "page.en.po"), "utf8");
+    assert.equal(pagePo.includes('msgid "sign-in"'), true);
+    assert.equal(pagePo.includes('msgid "Friends"'), false);
+    assert.equal(pagePo.includes('msgid "server-only"'), false);
+    assert.deepEqual(dynamicImportSpecs, [route]);
+});
+
+test("keeps default path excludes when custom excludes are configured", async () => {
+    const entrypoint = "entry.ts";
+    const dependency = String.raw`D:\repos\log\node_modules\.pnpm\pkg\node_modules\pkg\index.js`;
+    let resolvedDependency = false;
+
+    const plugin: Plugin = {
+        name: "default-exclude-spy",
+        setup(build) {
+            build.onResolve({ filter: /.*/, namespace: "source" }, ({ path }) => {
+                if (path === dependency) {
+                    resolvedDependency = true;
+                }
+                return undefined;
+            });
+            build.onLoad({ filter: /.*/, namespace: "source" }, (args) => ({ ...args, data: "" }));
+            build.onProcess({ filter: /.*/, namespace: "source" }, (args) => {
+                build.resolve({
+                    entrypoint: args.entrypoint,
+                    path: dependency,
+                    namespace: "source",
+                });
+                return undefined;
+            });
+        },
+    };
+
+    const config = defineConfig({
+        entrypoints: entrypoint,
+        exclude: /custom-skip/,
+        plugins: () => [plugin],
+    });
+    await run(config.entrypoints[0], { config });
+
+    assert.equal(resolvedDependency, false);
 });


### PR DESCRIPTION
## Summary

Fixes extractor dependency walking so shared runtime infrastructure cannot accidentally pull unrelated route translations into a page bundle.

## Root Cause

The extractor treated every discovered import as the same kind of dependency and applied exclude rules before enough import context was available. Custom excludes also replaced the default path guards, which could allow `node_modules`, `dist`, and `build` paths to be traversed on Windows.

## Changes

- Classify imports as static or dynamic and type-only or runtime.
- Add typed import metadata to resolve args so exclude callbacks can inspect the resolved import path and kind.
- Add named default exclude matchers: `modules`, `dist`, `build`, and `types`.
- Let configs select named default excludes with a factory, similar to plugin selection.
- Ignore Node builtins during import resolution to avoid noisy unresolved warnings.
- Add regressions for Windows `node_modules` paths, type-only imports, dynamic route imports, and resolved import metadata.

## Validation

- `node --test src/tests/configuration.test.ts src/tests/run.test.ts src/plugins/core/tests/resolve.test.ts src/plugins/core/queries/tests/import.test.ts`
- `npx biome check extract/src/plugin.ts extract/src/exclude.ts extract/src/configuration.ts extract/src/run.ts extract/src/plugins/core/core.ts extract/src/plugins/core/parse.ts extract/src/plugins/core/queries/import.ts extract/src/plugins/core/queries/types.ts extract/src/plugins/core/resolve.ts extract/src/plugins/core/queries/tests/import.test.ts extract/src/plugins/core/tests/resolve.test.ts extract/src/tests/configuration.test.ts extract/src/tests/run.test.ts`
- `npm --workspace extract run typecheck`